### PR TITLE
Update proxy.js

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -231,15 +231,20 @@ function getTarget(src, routing, req){
       }else{
         target = host[keys[0]];
       }
-
+      
+      if(!target) {
+        log.warn(src, 'no valid target found for given source')
+        return;
+      }
+      
       if(target.pathname){
         req.url = path.join(target.pathname, req.url);
       }
 
-      log.info("Proxing %s to %s", src, target.host + req.url)
+      log.info("Proxying %s to %s", src, target.host + req.url)
       return target;
     }else{
-     log.warn(src, 'no valid target found for given source') 
+     log.warn(src, 'no valid host found for given source') 
     }
 }
 


### PR DESCRIPTION
Using the following test_proxy.js:

var proxy = require('redbird')({port: 8080});

proxy.register("localhost:8080/test_1", "http://localhost:1337");
proxy.register("localhost:8080/test_2", "http://localhost:1338");
proxy.register("localhost:8080/test_3", "http://localhost:1339");

If I attempted to use the url "http://localhost:8080/test_unknown" the node server would throw the following error"

```
  if(target.pathname){
           ^
  TypeError: Cannot read property 'pathname' of undefined
```

The target variable is undefined because none of the routes/keys could be matched and the ".pathname" dereference causes the process to terminate.

I've just added a test make sure its valid and then log a warning about the target, and also altered the other warning to indicate a host which wasn't found.

Tested on OSX 10.9.
