### PR TITLE
http-proxy alters req.url based on target, now not adding path prefix prematurely

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -35,7 +35,8 @@ function ReverseProxy(opts){
   // Create a proxy server with custom application logic
   //
   var proxy = this.proxy = httpProxy.createProxyServer({
-    xfwd: true
+    xfwd: true,
+    prependPath: false
   });
   
   proxy.on('proxyReq', function(p, req, res, options) {


### PR DESCRIPTION
Fantastic codebase!

I've been having trouble proxying with paths. This configuration works fine:

``` js
proxy.register('awesomeserver.com/path', 'http://127.0.0.1:4000');
```

If I curl `http://awesomeserver.com/path/a/b/c` it does a proxy request for `/a/b/c` from port 4000 which is what I expected - a way to 'mount' another site inside a path. All requests have the path removed from them.

However if I have the following configuration:

``` js
proxy.register('awesomeserver.com/path', 'http://127.0.0.1:4000/path2');
```

I expect a curl `http://awesomeserver.com/path/a/b/c` to perform a proxy request for `/path2/a/b/c`. Instead it performs a request for `/path2/path2/a/b/c`.

Having done some work with http-proxy I notice you're prefixing the req.url and passing in a target with a path - http-proxy does the prefixing itself so this is where it's doubling up.

So here's a pull-request that stops redbird adding the prefixed path to req.url. The other option to fix would be to remove the path from the target url instead, I'm not sure about your project direction to understand which one makes the most sense. Here we're saying to http-proxy "Go to this sub path based on this additional url that also includes a path". E.g. Go to '/a/b/c' based on 'http://127.0.0.1:4000/path2'.
