### PR TITLE
Host headers as registered are passed through to the target

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -37,6 +37,12 @@ function ReverseProxy(opts){
   var proxy = this.proxy = httpProxy.createProxyServer({
     xfwd: true
   });
+  
+  proxy.on('proxyReq', function(p, req, res, options) {
+    if (req.host != null) {
+      p.setHeader('host', req.host);
+    }
+  });
 
   // 
   // Standard HTTP Proxy Server.
@@ -282,6 +288,10 @@ ReverseProxy.prototype._getTarget = function(src, req){
   if(target.pathname){
     req.url = path.join(target.pathname, req.url);
   }
+  
+  
+  // pass the target host to the proxy so we can provide a host header
+  req.host = target.host;
 
   this.log && this.log.info("Proxying %s to %s", src + url, target.host + req.url)
 

--- a/test/test_hostheader.js
+++ b/test/test_hostheader.js
@@ -1,0 +1,50 @@
+"use strict";
+
+var Redbird = require('../');
+var Promise = require('bluebird');
+var http = require('http');
+var expect = require('chai').expect;
+
+var TEST_PORT = 54674
+var PROXY_PORT = 53433
+
+var opts = {
+  port: PROXY_PORT,
+	bunyan: false
+}
+
+describe("Target with a hostname", function(){
+
+	it("Should have the host header passed to the target", function(done){
+		var redbird = Redbird(opts);
+
+		expect(redbird.routing).to.be.an("object");
+
+		redbird.register('127.0.0.1', '127.0.0.1.xip.io:'+TEST_PORT);
+
+		expect(redbird.routing).to.have.property("127.0.0.1");
+
+    testServer().then(function(req){
+      expect(req.headers['host']).to.be.eql('127.0.0.1.xip.io:'+TEST_PORT)
+    })
+
+    http.get('http://127.0.0.1:'+PROXY_PORT, function(res) {
+      redbird.close();
+      done();
+    });
+    
+	})
+})
+
+
+function testServer(){
+	return new Promise(function(resolve, reject){
+		var server = http.createServer(function(req, res){
+      res.write("");
+      res.end();
+			resolve(req);
+      server.close();
+		});
+		server.listen(TEST_PORT);
+	})
+}


### PR DESCRIPTION
When proxying to a server running nginx or apache host headers are needed to make sure the webserver selects the correct website. http-proxy simply passes on the current request object, and passes through a host header that matches the `source`.

If I'm pulling together an existing, legacy api into a new url structure I want the ability to set the host header to the `target`. e.g.

``` js
proxy.register('api.awesomecompany.com/legacy/v0', 'http://awesomecompany.com/api/cgi-bin/FOO/BAR');
```

The server that responds to awesomecompany.com (the target) also serves up other subdomains and the website notsoawesomecompany.com. It needs the target host header `awesomecompany.com` so it knows what website to serve. The existing redbird / http-proxy code just passes on the `source` host header. So a request is made to the webserver hosting `awesomecompany.com` for the host header `api.awesomecompany.com`. The DNS entry for `api.awesomecompany.com` does not point to the target server and the target server doesn't know what to do with the request. As a result I suggest using the target host for the host header, as implemented in this pull request.

However I imagine that you might want your target to know the `actual` host header it's handling, you might want it to believe it's the real server. You can get the original host and port through the `x-forwarded-` header entries, but that might not be enough for some situations.

It would be interesting to have some discussion about this. I think host header proxying is very useful for my use case and does not impact many other use cases such as direct IP and port proxying.
