### PR TITLE
Added configuration option for passing hostheader from target

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -159,7 +159,7 @@ ReverseProxy.prototype.register = function(src, target, opts){
   target = prepareUrl(target);
   
   target.sslRedirect = true;
-  target.useSourceHostHeader = false;
+  target.useTargetHostHeader = false;
 
   if(opts){
     if(opts.ssl){
@@ -177,7 +177,7 @@ ReverseProxy.prototype.register = function(src, target, opts){
         this.certs[src.hostname] = undefined; 
       }
     }
-    target.useSourceHostHeader = opts.useSourceHostHeader === true ? true : false;
+    target.useTargetHostHeader = opts.useTargetHostHeader === true ? true : false;
   }
   
   var host = routing[src.hostname] = routing[src.hostname] || [];
@@ -297,7 +297,7 @@ ReverseProxy.prototype._getTarget = function(src, req){
   // Host headers are passed through from the source by default
   // Often we want to use the host header of the target instead
   //
-  if (target.useSourceHostHeader === false) {
+  if (target.useTargetHostHeader === true) {
     req.host = target.host;
   }
 

--- a/test/test_hostheader.js
+++ b/test/test_hostheader.js
@@ -20,7 +20,9 @@ describe("Target with a hostname", function(){
 
 		expect(redbird.routing).to.be.an("object");
 
-		redbird.register('127.0.0.1', '127.0.0.1.xip.io:'+TEST_PORT);
+		redbird.register('127.0.0.1', '127.0.0.1.xip.io:'+TEST_PORT, {
+			useTargetHostHeader: true
+		});
 
 		expect(redbird.routing).to.have.property("127.0.0.1");
 
@@ -40,9 +42,7 @@ describe("Target with a hostname", function(){
 
 		expect(redbird.routing).to.be.an("object");
 
-		redbird.register('127.0.0.1', '127.0.0.1.xip.io:'+TEST_PORT, {
-			useSourceHostHeader: true
-		});
+		redbird.register('127.0.0.1', '127.0.0.1.xip.io:'+TEST_PORT);
 
 		expect(redbird.routing).to.have.property("127.0.0.1");
 


### PR DESCRIPTION
The host header of the target is currently used for proxy requests by default. This is great for pulling together existing websites into better url structures, and to mimic the functionality of existing services at different urls. However if redbird is used to provide https and load balancing then the source host header is the one that is wanted to pass through. The target may be nodejs running in a high port range. Because websites run in different environments it's common practice to use the host header itself for construction of urls and the nodejs server won't have knowledge of the actual external host unless the host header from the source is passed through.

I believe there are three solutions:
1. If the target is an IP address use the host header from the source.
2. Create a configuration option for using the target's host header - by default use the source host header.
3. Create a configuration option for using the source host header - by default use the target host header.

The first option is a little mysterious and not immediately obvious, code should probably be explicit so I would suggest not going with IP address detection.

I would select options 2 or 3 depending on the intended use of redbird. If redbird is a load balancer / proxy server for pulling together nodejs web servers then I would go with option 2. If redbird is a tool to compose existing services then I would go with option 3.

I've implemented option 2 as I suspect redbird is primarily suited to load balancing nodejs web servers.

``` js
// target will be requested with a host header of 'source.com' (default)
redbird.register('source.com', '127.0.0.1:8820');

// target will be requested with a host header of '127.0.0.1:8820'
redbird.register('source.com', '127.0.0.1:8820', {
  useTargetHostHeader: true
});
```
