### PR TITLE
Register and proxy to a custom function

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -59,7 +59,10 @@ function ReverseProxy(opts){
       if(certs && src in certs && target.sslRedirect){
         req.url = req._url || req.url; // Get the original url since we are going to redirect.
         redirectToHttps(req, res, target, opts.ssl, log);
-      }else{
+      }else if (typeof(target) == 'function') {
+        target(req, res, proxy);
+      }
+      else {
         proxy.web(req, res, {target: target});
       }
     }else {
@@ -145,7 +148,7 @@ function ReverseProxy(opts){
   @src {String|URL} A string or a url parsed by node url module.
   Note that port is ignored, since the proxy just listens to one port.
 
-  @target {String|URL} A string or a url parsed by node url module.
+  @target {String|URL|Function} A string, function or url parsed by node url module.
   @opts {Object} Route options.
 */
 ReverseProxy.prototype.register = function(src, target, opts){
@@ -219,7 +222,7 @@ ReverseProxy.prototype.unregister = function(src, target){
     if(target){
       target = prepareUrl(target);  
       _.remove(route.urls, function(url){
-        return url.href == target.href;
+        return url.href == target.href || url === target;
       });
     }else{
       route.urls = []

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -107,7 +107,12 @@ function ReverseProxy(opts){
       var src = getSource(req);
       var target = _this._getTarget(src, req);
       if(target){
-        proxy.web(req, res, {target: target});
+        if (typeof(target) == 'function') {
+          target(req, res, proxy);
+        }
+        else {
+          proxy.web(req, res, {target: target});
+        }
       }else {
         notFound(res);
       }
@@ -127,7 +132,12 @@ function ReverseProxy(opts){
     var target = _this._getTarget(src, req);
     log && log.info({headers: req.headers, target: target}, "upgrade to websockets");
     if(target){
-      proxy.ws(req, socket, head, {target: target});
+      if (typeof(target) == 'function') {
+        target(req, socket, head, proxy);
+      }
+      else {
+        proxy.ws(req, socket, head, {target: target});
+      }
     }else{
       notFound(socket);
     }

--- a/test/test_hostheader.js
+++ b/test/test_hostheader.js
@@ -34,6 +34,30 @@ describe("Target with a hostname", function(){
     });
     
 	})
+	
+	it("should resolve a custom route", function(done){
+		var redbird = Redbird(opts);
+
+		expect(redbird.routing).to.be.an("object");
+
+		var testFunc = function(req, res, proxy) {
+			proxy.web(req, res, {target: 'http://127.0.0.1:'+TEST_PORT});
+		};
+		redbird.register('127.0.0.1', testFunc);
+
+		expect(redbird.routing).to.have.property("127.0.0.1");
+
+		var passed = false;
+    testServer().then(function(req){
+      passed = true;
+    });
+
+    http.get('http://127.0.0.1:'+PROXY_PORT, function(res) {
+      redbird.close();
+      expect(passed).to.be.eql(true);
+      done();
+    });
+	})
 })
 
 


### PR DESCRIPTION
Logging requests, checking permissions and other use cases require a custom function for every request going through redbird. This pull request adds the following syntax:

```js
redbird.register('example.com', function(req, res, proxy) {
	proxy.web(req, res, {target: 'http://192.168.1.2:8080/'});
});
```
Which is equivalent to:
```js
redbird.register('example.com', '192.168.1.2:8080');
```

However with the new syntax we are able to return a 404, perform permission checking or proxy to a different url per request.

Internally the array is still called urls, which is something I can cleanup if needed. Also the readme should probably be updated with this new syntax. I'm happy to do both of these if this is a piece of functionality that is welcome in redbird. At the moment there is no parameter to access any options set for the route which may be an addition we want to consider.

Let me know what you think.