### PR TITLE
Fixed "Cannot read property 'length' of undefined" on unregister when ho...

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -203,7 +203,7 @@ ReverseProxy.prototype.unregister = function(src, target){
   if(!src) return;
 
   src = prepareUrl(src);
-  var routes = this.routing[src.hostname];
+  var routes = this.routing[src.hostname] || [];
   var pathname = src.pathname || '/';
   var i;
 

--- a/test/test_register.js
+++ b/test/test_register.js
@@ -126,6 +126,15 @@ describe("Route registration", function(){
 
 		redbird.close();
 	})
+	it("shouldnt crash process in unregister of unregisted host", function(done){
+		var redbird = Redbird(opts);
+
+		redbird.unregister('example.com');
+
+		done()
+
+		redbird.close();
+	})
 })
 
 describe("Route resolution", function(){


### PR DESCRIPTION
On unregister function if host hasn't been added yet `this.routing[src.hostname]` returned undefined and the process crashed a couple of lines after on `for(i=0; i<routes.length; i++){`. I didn't know if i should add a test for this or if this didn't need a test, so I added it. 

Have been using the project a little and its awesome, thanks for building it. Also, I could donate time to add support for Redis backend if you tell me what you have in mind with it, I see that there is already a file for this.
