### PR TITLE
After unregistering server returned a 200, it should be a 404

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -396,8 +396,8 @@ function getSource(req){
 */
 
 function notFound(res){
-  res.write('Not Found');
   res.statusCode = 404;
+  res.write('Not Found');
   res.end();
 }
 

--- a/test/test_hostheader.js
+++ b/test/test_hostheader.js
@@ -56,6 +56,29 @@ describe("Target with a hostname", function(){
     });
     
 	})
+
+	it("Should return 404 after route is unregister", function(done){
+		var redbird = Redbird(opts);
+
+		expect(redbird.routing).to.be.an("object");
+
+		redbird.register('127.0.0.1', '127.0.0.1.xip.io:'+TEST_PORT);
+		redbird.unregister('127.0.0.1', '127.0.0.1.xip.io:'+TEST_PORT);
+
+		expect(redbird.routing).to.have.property("127.0.0.1");
+
+    testServer().then(function(req){
+      expect(req.headers['host']).to.be.eql('127.0.0.1:'+PROXY_PORT)
+    })
+
+    http.get('http://127.0.0.1:'+PROXY_PORT, function(res) {
+      expect(res.statusCode).to.be.eql(404);
+
+      redbird.close();
+      done();
+    });
+
+	})
 })
 
 


### PR DESCRIPTION
Doing `res.write` before setting the headers sends a 200 as status.