### PR TITLE
Add the option of having an https target

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,12 @@ redbird.register('foobar.com', 'http://172.60.80.3:8082', {
 ```js
 var redbird = require('redbird')({
 	port: 80,
-        secure: false,
-        ssl: {
-                port: 443,
-                key: "../certs/default.key",
-                cert: "../certs/default.crt",
-        }
+	secure: false,
+	ssl: {
+		port: 443,
+		key: "../certs/default.key",
+		cert: "../certs/default.crt",
+	}
 });
 redbird.register('tutorial.com', 'https://172.60.80.2:8083', {
 	ssl: {

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Developed by [manast](http://twitter.com/manast)
 
 [![BuildStatus](https://secure.travis-ci.org/OptimalBits/redbird.png?branch=master)](http://travis-ci.org/OptimalBits/redbird)
 [![NPM version](https://badge.fury.io/js/redbird.svg)](http://badge.fury.io/js/redbird)
+[![redbird](https://ghit.me/badge.svg?repo=joelself/redbird)](https://ghit.me/repo/joelself/redbird)
 
 This a minor fork of the main redbird source to allow https targets and an option to specify whether the connection to the target should be secure or not.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Redbird Reverse Proxy
+Redbird Reverse Proxy *now with HTTPS targets!*
 =====================
 
 ![redbird](http://cliparts.co/cliparts/6cr/o9d/6cro9dRzi.jpg)
@@ -15,6 +15,8 @@ Developed by [manast](http://twitter.com/manast)
 
 [![BuildStatus](https://secure.travis-ci.org/OptimalBits/redbird.png?branch=master)](http://travis-ci.org/OptimalBits/redbird)
 [![NPM version](https://badge.fury.io/js/redbird.svg)](http://badge.fury.io/js/redbird)
+
+This a minor fork of the main redbird source to allow https targets and an option to specify whether the connection to the target should be secure or not.
 
 ##Install
 
@@ -130,6 +132,27 @@ redbird.register('foobar.com', 'http://172.60.80.3:8082', {
 		cert: "../certs/foobar.crt",	
 	}
 });
+```
+
+*New!* Now you can specify https hosts as targets and also specify if you want the connection to the target host to be secure (default is true).
+
+```js
+var redbird = require('redbird')({
+	port: 80,
+        secure: false,
+        ssl: {
+                port: 443,
+                key: "../certs/default.key",
+                cert: "../certs/default.crt",
+        }
+});
+redbird.register('tutorial.com', 'https://172.60.80.2:8083', {
+	ssl: {
+		key: "../certs/tutorial.key",
+		cert: "../certs/tutorial.crt",
+	}
+});
+
 ```
 
 ##Docker support

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -53,7 +53,8 @@ function ReverseProxy(opts){
     //
     var proxy = this.proxy = httpProxy.createProxyServer({
       xfwd: (opts.xfwd != false) ? true : false,
-      prependPath: false
+      prependPath: false,
+      secure: (opts.secure != false) ? true : false
     });
   
     proxy.on('proxyReq', function(p, req){
@@ -425,7 +426,7 @@ function prepareUrl(url){
   if(_.isString(url)){
     url = setHttp(url);
 
-    if(!validUrl.isHttpUri(url)){
+    if(!validUrl.isHttpUri(url) && !validUrl.isHttpsUri(url)){
       throw Error('uri is not a valid http uri ' + url);
     }
 


### PR DESCRIPTION
And whether the connection to the target is secure or not.

Other sites and services I can have unsecured behind a secure redbird proxy, but WordPress will still try to load all of its resources over http unless you explicitly set the WordPress address to be https. If I do that though I can't put it behind redbird. So I made a small change to allow https targets and also an option to securely connect to the target (since Node doesn't trust my StartSSL cert,  and I couldn't figure out how to get Node to trust it).