### PR TITLE
Added ntlm: boolean option to lib/proxy.js which when true adds a pro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,18 @@ var redbird = new require('redbird')({
 });
 ```
 
+##NTLM support
+If you need NTLM support, you can tell Redbird to add the required header handler. This 
+registers a response handler which makes sure the NTLM auth header is properly split into
+two entries from http-proxy.
+
+```js
+var redbird = new require('redbird')({
+  port: 8080,
+  ntlm: true
+});
+```
+
 ##Roadmap
 
 - Statistics (number of connections, load, response times, etc)

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -56,12 +56,20 @@ function ReverseProxy(opts){
       prependPath: false,
       secure: (opts.secure != false) ? true : false
     });
-  
+ 
     proxy.on('proxyReq', function(p, req){
       if(req.host != null){
         p.setHeader('host', req.host);
       }
     });
+			
+    //To Support NTLM auth
+    if(opts.ntlm){
+      proxy.on('proxyRes', function (proxyRes) {
+        var key = 'www-authenticate';
+        proxyRes.headers[key] = proxyRes.headers[key] && proxyRes.headers[key].split(',');
+      });
+    }
   
     //
     // Standard HTTP Proxy Server.


### PR DESCRIPTION
…xy handler from http-proxy to split ntlm auth headers into two fields instead of a single array. This resolves issues with NTLM authentication behind a redbird proxy.

This resolves issue [#13](https://github.com/OptimalBits/redbird/issues/13).