### PR TITLE
Bump version for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redbird",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "A reverse proxy with support for dynamic tables",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is just so that npm can publish the new NTLM support pull.