### PR TITLE
Update http-proxy to 1.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bluebird": "^2.2.2",
     "bunyan": "^1.0.0",
     "dolphin": "^0.0.7",
-    "http-proxy": "1.11.1",
+    "http-proxy": "1.12.1",
     "lodash": "^2.4.1",
     "valid-url": "^1.0.9"
   },


### PR DESCRIPTION
1.12.1 is a NTLM patch for broken response headers during the authentication phase of the NTCR response.

It is completely separate issue from the previous Redbird merge which adds support for NTLM authentication.