### PR TITLE
Update package for new npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redbird",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "A reverse proxy with support for dynamic tables",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I'm sorry to keep bugging you but it would be really nice if this update was published on npm. This is the last NTLM update needed. And once again I'm sorry I didn't wait until the http-proxy bug was patched before submitting the pull request to Redbird. I'm new to npm publishing and didn't realize it didn't auto-update from github (no idea why I thought it would).