### PR TITLE
Custom resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Resolvers should be:
 
 ```
   {
-     url: string or array of string [required],
+     url: string or array of string [required], when array, the urls will be load-balanced across.
      path: path prefix for route, [optional], defaults to '/',
      opts: {} //redbird target options, see Redbird.register() [optional],
   }
@@ -266,7 +266,13 @@ You can add or remove resolvers at runtime, this is useful in situations where y
 
 ```javascript
 var topPriority = function(host, url) {
-  return /app\.example\.com/.test(host) ? 'http://127.0.0.1:8000' : null;
+  return /app\.example\.com/.test(host) ? {
+    //load balanced
+    url: [
+    'http://127.0.0.1:8000',
+    'http://128.0.1.1:9999'
+   ]
+  } : null;
 };
 
 topPriority.priority = 200;

--- a/README.md
+++ b/README.md
@@ -207,6 +207,79 @@ var redbird = new require('redbird')({
 });
 ```
 
+
+##Custom Resolvers
+
+With custom resolvers, you can decide how the proxy server handles request. Custom resolvers allow you to extend redbird considerably. With custom resolvers, you can perform the following:
+
+- Do path-based routing
+- Do wildcard domain routing.
+- Use variable upstream servers based on availability, for example in conjunction with Etcd or any other service discovery platform.
+- And more.
+
+Resolvers should be:
+
+  1. Be invokable function. The `this` context of such function is the Redbird Proxy object. The resolver function takes in two parameters : `host` and `url`
+  2. Have a priority, resolvers with higher priorities are called before those of lower priorities. The default resolver, has a priority of 0.
+  3. A resolver should return a route object or a string when matches it matches the parameters passed in. If string is returned, then it must be a valid upstream URL, if object, then the object must conform to the following:
+
+```
+  {
+     url: string or array of string [required],
+     path: path prefix for route, [optional], defaults to '/',
+     opts: {} //redbird target options, see Redbird.register() [optional],
+  }
+```
+
+### Defining Resolvers
+
+Resolvers can be defined when initializing the proxy object with the `resolvers` parameter. An example is below:
+
+```javascript
+ //for every URL path that starts with /api/, send request to upstream API service
+ var customResolver1 = function(host, url) {
+   if(/^\/api\//.test(url)){
+      return 'http://127.0.0.1:8888';
+   }
+ };
+
+ //assign high priority
+ customResolver1.priority = 100;
+
+ var proxy = new require('redbird')({
+    port: 8080,
+    resolvers: [
+    customResolver1,
+    //uses the same priority as default resolver, so will be called after default resolver
+    function(host, url) {
+      if(/\.example\.com/.test(host)){
+        return 'http://127.0.0.1:9999'
+      }
+    }]
+ })
+
+```
+
+### Adding and Removing Resolvers at Runtime.
+
+You can add or remove resolvers at runtime, this is useful in situations where your upstream is tied to a service discovery service system.
+
+```javascript
+var topPriority = function(host, url) {
+  return /app\.example\.com/.test(host) ? 'http://127.0.0.1:8000' : null;
+};
+
+topPriority.priority = 200;
+proxy.addResolver(topPriority);
+
+
+//remove top priority after 10 minutes,
+setTimeout(function() {
+  proxy.removeResolver(topPriority);
+}, 600000);
+```
+
+
 ##Roadmap
 
 - Statistics (number of connections, load, response times, etc)
@@ -226,7 +299,7 @@ the given port.
 
 __Arguments__
 
-```javascript
+```
     opts {Object} Options to pass to the proxy:
     {
     	port: {Number} // port number that the proxy will listen to.
@@ -241,6 +314,7 @@ __Arguments__
         bunyan: {Object} Bunyan options. Check [bunyan](https://github.com/trentm/node-bunyan) for info.
         If you want to disable bunyan, just set this option to false. Keep in mind that
         having logs enabled incours in a performance penalty of about one order of magnitude per request.
+        resolvers: {Function | Array}  a list of custom resolvers. Can be a single function or an array of functions. See more details about resolvers above.
 	}
 ```
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -9,7 +9,10 @@ var
   path = require('path'),
   _ = require('lodash'),
   bunyan = require('bunyan'),
-  cluster = require('cluster');
+  cluster = require('cluster'),
+  hash = require('object-hash'),
+  routeCache = {}
+  ;
 
 function ReverseProxy(opts){
   if(!(this instanceof ReverseProxy)){
@@ -42,7 +45,12 @@ function ReverseProxy(opts){
     });
   } else {
     opts.port = opts.port || 8080;
-      
+
+    this.resolvers = [this._defaultResolver];
+    if(opts.resolvers){
+      this.addResolver(opts.resolvers);
+    }
+
     //
     // Routing table.
     //
@@ -52,9 +60,9 @@ function ReverseProxy(opts){
     // Create a proxy server with custom application logic
     //
     var proxy = this.proxy = httpProxy.createProxyServer({
-      xfwd: (opts.xfwd != false) ? true : false,
+      xfwd: (opts.xfwd != false),
       prependPath: false,
-      secure: (opts.secure != false) ? true : false
+      secure: (opts.secure !== false)
     });
  
     proxy.on('proxyReq', function(p, req){
@@ -92,13 +100,13 @@ function ReverseProxy(opts){
         notFound(res);
       }
     });
-  
+
     //
     // Listen to the `upgrade` event and proxy the
     // WebSocket requests as well.
     //
     server.on('upgrade', websocketsUpgrade);
-  
+
     server.on('error', function(err){
       log && log.error(err, 'Server Error');
     });
@@ -124,19 +132,19 @@ function ReverseProxy(opts){
         key: getCertData(opts.ssl.key),
         cert: getCertData(opts.ssl.cert)
       };
-  
+
       if(opts.ssl.ca){
         ssl.ca = getCertData(opts.ssl.ca, true);
       }
-  
+
       if(opts.ssl.opts){
         ssl = _.defaults(ssl, opts.ssl.opts);
       }
-  
+
       var httpsServer = this.httpsServer = https.createServer(ssl, function(req, res){
-  
+
         var src = getSource(req);
-  
+
         var target = _this._getTarget(src, req);
         if(target){
           proxy.web(req, res, {target: target});
@@ -144,21 +152,21 @@ function ReverseProxy(opts){
           notFound(res);
         }
       });
-  
+
       httpsServer.on('upgrade', websocketsUpgrade);
-  
+
       httpsServer.on('error', function(err){
         log && log.error(err, 'HTTPS Server Error');
       });
-  
+
       httpsServer.on('clientError', function(err){
         log && log.error(err, 'HTTPS Client  Error');
       });
-  
+
       log && log.info('Listening to HTTPS requests on port %s', opts.ssl.port);
       httpsServer.listen(opts.ssl.port);
     }
-    
+
     proxy.on('error', function(err, req, res){
       //
       // Send a 500 http status if headers have been sent
@@ -166,7 +174,7 @@ function ReverseProxy(opts){
       if(!res.headersSent){
         res.writeHead && res.writeHead(500);
       }
-  
+
       //
       // Do not log this common error
       //
@@ -174,12 +182,12 @@ function ReverseProxy(opts){
         log && log.error(err, 'Proxy Error');
       }
     });
-  
+
     server.listen(opts.port);
-  
+
     log && log.info(opts.port, 'Started a Redbird reverse proxy server');
   }
-  
+
   function websocketsUpgrade(req, socket, head){
     var src = getSource(req);
     var target = _this._getTarget(src, req);
@@ -192,18 +200,60 @@ function ReverseProxy(opts){
   }
 }
 
+ReverseProxy.prototype.addResolver = function (resolver) {
+  if(this.opts.cluster && cluster.isMaster) return this;
+
+  if(!_.isArray(resolver)){
+    resolver = [resolver];
+  }
+
+  var _this = this;
+  resolver.forEach(function (resolveObj) {
+    if(!_.isFunction(resolveObj)){
+      throw new Error("Resolver must be an invokable function.");
+    }
+
+    if(!resolveObj.hasOwnProperty('priority')){
+      resolveObj.priority = 0;
+    }
+
+    _this.resolvers.push(resolveObj);
+  });
+
+  _.sortBy(_this.resolvers, function (r) {
+    return -r.priority;
+  });
+};
+
+ReverseProxy.prototype.removeResolver = function (resolver) {
+  if(this.opts.cluster && cluster.isMaster) return this;
+  //since unique resolvers are not checked for performance,
+  //just remove every existence.
+  this.resolvers = this.resolvers.filter(function (resolverFn) {
+    return resolverFn !== resolver;
+  });
+};
+
+ReverseProxy.buildTarget = function (target, opts) {
+  opts = opts || {};
+  target = prepareUrl(target);
+  target.sslRedirect =  !opts.ssl || opts.ssl.redirect !== false;
+  target.useTargetHostHeader = opts.useTargetHostHeader === true;
+  return target;
+};
+
 /**
-  Register a new route.
+ Register a new route.
 
-  @src {String|URL} A string or a url parsed by node url module.
-  Note that port is ignored, since the proxy just listens to one port.
+ @src {String|URL} A string or a url parsed by node url module.
+ Note that port is ignored, since the proxy just listens to one port.
 
-  @target {String|URL} A string or a url parsed by node url module.
-  @opts {Object} Route options.
-*/
+ @target {String|URL} A string or a url parsed by node url module.
+ @opts {Object} Route options.
+ */
 ReverseProxy.prototype.register = function(src, target, opts){
   if(this.opts.cluster && cluster.isMaster) return this;
-  
+
   if(!src || !target){
     throw Error('Cannot register a new route with unspecified src or target');
   }
@@ -211,10 +261,6 @@ ReverseProxy.prototype.register = function(src, target, opts){
   var routing = this.routing;
 
   src = prepareUrl(src);
-  target = prepareUrl(target);
-
-  target.sslRedirect = true;
-  target.useTargetHostHeader = false;
 
   if(opts){
     if(opts.ssl){
@@ -222,20 +268,17 @@ ReverseProxy.prototype.register = function(src, target, opts){
         throw Error('Cannot register https routes without defining a ssl port');
       }
 
-      target.sslRedirect = opts.ssl.redirect === false ? false : true;
-
       if(!this.certs[src.hostname]){
         if(opts.ssl.key || opts.ssl.cert || opts.ssl.ca){
-          var cert = createCredentialContext(opts.ssl.key, opts.ssl.cert, opts.ssl.ca);
-          this.certs[src.hostname] = cert;
+          this.certs[src.hostname] = createCredentialContext(opts.ssl.key, opts.ssl.cert, opts.ssl.ca);
         }else{
           // Trigger the use of the default certificates.
           this.certs[src.hostname] = void 0;
         }
       }
     }
-    target.useTargetHostHeader = opts.useTargetHostHeader === true ? true : false;
   }
+  target = ReverseProxy.buildTarget(target, opts);
 
   var host = routing[src.hostname] = routing[src.hostname] || [];
   var pathname = src.pathname || '/';
@@ -298,7 +341,7 @@ ReverseProxy.prototype.unregister = function(src, target){
   return this;
 };
 
-ReverseProxy.prototype.resolve = function(host, url){
+ReverseProxy.prototype._defaultResolver = function(host, url){
   // Given a src resolve it to a target route if any available.
   if(!host){
     return;
@@ -323,6 +366,62 @@ ReverseProxy.prototype.resolve = function(host, url){
       }
     }
   }
+};
+
+ReverseProxy.prototype._defaultResolver.priority = 0;
+
+/**
+ * Resolves to route
+ * @param host
+ * @param url
+ * @returns {*}
+ */
+ReverseProxy.prototype.resolve = function(host, url){
+  var route;
+  for(var i=0; i < this.resolvers.length; i++){
+    route = this.resolvers[i].call(this, host, url);
+    if(route && (_.isString(route) || _.isObject(route))){
+      //ensure resolved route has path that prefixes URL
+      //no need to check for native routes.
+      route = buildRoute(route);
+      if(!route.isResolved || startsWith(url, route.pathname)){
+        return route;
+      }
+    }
+  }
+};
+
+var buildRoute = function (route) {
+
+  if(_.isObject(route) && route.hasOwnProperty('urls') && route.hasOwnProperty('pathname')){
+    //default route type matched.
+    return route;
+  }
+
+  var cacheKey = _.isString(route) ? route : hash(route);
+  if(routeCache.hasOwnProperty(cacheKey)){
+    return routeCache[cacheKey];
+  }
+
+  var routeObject = {rr: 0, isResolved: true};
+  if(_.isString(route)){
+    routeObject.urls = [ReverseProxy.buildTarget(route)];
+    routeObject.pathname = '/';
+  } else {
+    if(!route.hasOwnProperty('url')){
+      return null;
+    }
+
+    routeObject.urls = (_.isArray(route.url) ? route.url : [route.url]).map(function (url) {
+      return ReverseProxy.buildTarget(url, route.options)
+    });
+
+    routeObject.pathname = route.path || '/';
+  }
+
+  //cache routes for easy referencing. It's not likely to change.
+  return routeCache[cacheKey] = routeObject;
+
 };
 
 ReverseProxy.prototype._getTarget = function(src, req){
@@ -431,8 +530,8 @@ function redirectToHttps(req, res, target, ssl, log){
 }
 
 function startsWith(input, str){
-  return input.slice(0, str.length) === str && 
-         (input.length === str.length || input[str.length] === '/')
+  return input.slice(0, str.length) === str &&
+    (input.length === str.length || input[str.length] === '/')
 }
 
 function prepareUrl(url){
@@ -471,9 +570,9 @@ function getCertData(pathname, unbundle){
 }
 
 /**
-  Unbundles a file composed of several certificates.
-  http://www.benjiegillam.com/2012/06/node-dot-js-ssl-certificate-chain/
-*/
+ Unbundles a file composed of several certificates.
+ http://www.benjiegillam.com/2012/06/node-dot-js-ssl-certificate-chain/
+ */
 function unbundleCert(bundle){
   var chain = bundle.trim().split('\n');
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -418,7 +418,7 @@ ReverseProxy.buildRoute = function (route) {
     }
 
     routeObject.urls = (_.isArray(route.url) ? route.url : [route.url]).map(function (url) {
-      return ReverseProxy.buildTarget(url, route.options)
+      return ReverseProxy.buildTarget(url, route.opts || {});
     });
 
     routeObject.path = route.path || '/';

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -220,9 +220,10 @@ ReverseProxy.prototype.addResolver = function (resolver) {
     _this.resolvers.push(resolveObj);
   });
 
-  _.sortBy(_this.resolvers, function (r) {
+  _this.resolvers = _.sortBy(_.uniq(_this.resolvers), function (r) {
     return -r.priority;
   });
+
 };
 
 ReverseProxy.prototype.removeResolver = function (resolver) {
@@ -380,33 +381,37 @@ ReverseProxy.prototype.resolve = function(host, url){
   var route;
   for(var i=0; i < this.resolvers.length; i++){
     route = this.resolvers[i].call(this, host, url);
-    if(route && (_.isString(route) || _.isObject(route))){
+    if(route && (route = ReverseProxy.buildRoute(route))){
       //ensure resolved route has path that prefixes URL
       //no need to check for native routes.
-      route = buildRoute(route);
-      if(!route.isResolved || startsWith(url, route.pathname)){
+
+      if(!route.isResolved || route.path === '/' || startsWith(url, route.path)){
         return route;
       }
     }
   }
 };
 
-var buildRoute = function (route) {
+ReverseProxy.buildRoute = function (route) {
+  if(!_.isString(route) && !_.isObject(route)){
+    return null;
+  }
 
-  if(_.isObject(route) && route.hasOwnProperty('urls') && route.hasOwnProperty('pathname')){
+  if(_.isObject(route) && route.hasOwnProperty('urls') && route.hasOwnProperty('path')){
     //default route type matched.
     return route;
   }
 
   var cacheKey = _.isString(route) ? route : hash(route);
   if(routeCache.hasOwnProperty(cacheKey)){
+    routeCache[cacheKey]._hits++;
     return routeCache[cacheKey];
   }
 
-  var routeObject = {rr: 0, isResolved: true};
+  var routeObject = {rr: 0, isResolved: true, _hits: 1};
   if(_.isString(route)){
     routeObject.urls = [ReverseProxy.buildTarget(route)];
-    routeObject.pathname = '/';
+    routeObject.path = '/';
   } else {
     if(!route.hasOwnProperty('url')){
       return null;
@@ -416,7 +421,7 @@ var buildRoute = function (route) {
       return ReverseProxy.buildTarget(url, route.options)
     });
 
-    routeObject.pathname = route.path || '/';
+    routeObject.path = route.path || '/';
   }
 
   //cache routes for easy referencing. It's not likely to change.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dolphin": "^0.0.7",
     "http-proxy": "1.12.1",
     "lodash": "^2.4.1",
+    "object-hash": "^1.1.2",
     "valid-url": "^1.0.9"
   },
   "devDependencies": {

--- a/test/test_custom_resolver.js
+++ b/test/test_custom_resolver.js
@@ -1,0 +1,221 @@
+"use strict";
+
+var Redbird = require('../');
+var expect = require('chai').expect;
+var _ = require('lodash');
+
+var opts = {
+	bunyan: false,
+  port: 10000 + Math.ceil(Math.random() * 55535)
+  /* {
+		name: 'test',
+		streams: [{
+        	path: '/dev/null',
+    	}]
+	} */
+};
+
+
+describe("Custom Resolver", function(){
+
+  it("Should contain one resolver by default", function () {
+
+    var redbird = Redbird(opts);
+    expect(redbird.resolvers).to.be.an('array');
+    expect(redbird.resolvers.length).to.be.eq(1);
+    expect(redbird.resolvers[0]).to.be.eq(redbird._defaultResolver);
+
+    redbird.close();
+  });
+
+	it("Should register resolver with right priority", function(){
+    var resolver = function () {
+      return 'http://127.0.0.1:8080';
+    };
+
+    resolver.priority = 1;
+
+    var options = _.extend({
+      resolvers: resolver
+    }, opts);
+
+		var redbird = Redbird(options);
+
+    expect(redbird.resolvers.length).to.be.eq(2);
+    expect(redbird.resolvers[0]).to.be.eql(resolver);
+
+		redbird.close();
+
+
+    //test when an array is sent in as resolvers.
+    options.resolvers = [resolver];
+    redbird = new Redbird(options);
+    expect(redbird.resolvers.length).to.be.eq(2);
+    expect(redbird.resolvers[0]).to.be.eql(resolver);
+    redbird.close();
+
+    resolver.priority = -1;
+    redbird = new Redbird(options);
+    expect(redbird.resolvers.length).to.be.eq(2);
+    expect(redbird.resolvers[1]).to.be.eql(resolver);
+    redbird.close();
+
+
+    //test when invalid resolver is added
+    options.resolvers = {};
+    expect(function () {
+       new Redbird(options)
+    }).to.throw(Error);
+
+
+  });
+
+
+  it('Should add and remove resolver after launch', function () {
+
+    var resolver = function () {};
+    resolver.priority = 1;
+
+    var redbird = Redbird(opts);
+    redbird.addResolver(resolver);
+    expect(redbird.resolvers.length).to.be.eq(2);
+    expect(redbird.resolvers[0]).to.be.eq(resolver);
+
+    redbird.addResolver(resolver);
+    expect(redbird.resolvers.length, 'Only allows uniques.').to.be.eq(2);
+
+
+    redbird.removeResolver(resolver);
+    expect(redbird.resolvers.length).to.be.eq(1);
+    expect(redbird.resolvers[0]).to.be.eq(redbird._defaultResolver);
+
+    redbird.close();
+
+  });
+
+  
+  it('Should properly convert and cache route to routeObject', function () {
+
+    var builder = Redbird.buildRoute;
+
+    //invalid input
+    expect(builder(function () {})).to.be.null;
+    expect(builder([])).to.be.null;
+    expect(builder(2016)).to.be.null;
+
+    var testRoute = {urls: [], path: '/'};
+    var testRouteResult = builder(testRoute);
+    expect(testRouteResult, 'For route in the default format').to.be.eq(testRoute);
+    expect(testRouteResult.isResolved).to.be.undefined;
+
+
+    //case string:
+    var testString = 'http://127.0.0.1:8888';
+    var result = builder(testString);
+    expect(result.path).to.be.eq('/');
+    expect(result.urls).to.be.an('array');
+    expect(result.urls.length).to.be.eq(1);
+    expect(result.urls[0].hostname).to.be.eq('127.0.0.1');
+    expect(result.isResolved).to.be.true;
+
+
+    var result2 = builder(testString);
+    expect(result2).to.be.eq(result);
+    expect(result2._hits).to.be.above(1);
+
+    //case with object
+
+     var testObject_1= {path:'/api', url: 'http://127.0.0.1'},
+       testObjectResult_1 = builder(testObject_1);
+
+    expect(testObjectResult_1.path).to.be.eq('/api');
+    expect(testObjectResult_1.urls).to.be.an('array');
+    expect(testObjectResult_1.urls.length).to.be.eq(1);
+    expect(testObjectResult_1.urls[0].hostname).to.be.eq('127.0.0.1');
+    expect(testObjectResult_1.isResolved).to.be.true;
+
+
+    //test object caching.
+    var testObjectResult_2 = builder(testObject_1);
+    expect(testObjectResult_1).to.be.eq(testObjectResult_2);
+    expect(testObjectResult_2._hits).to.be.above(1);
+
+    var testObject_2= {url: ['http://127.0.0.1', 'http://123.1.1.1']}
+    var testResult2  = builder(testObject_2);
+    expect(testResult2.urls).to.not.be.undefined;
+    expect(testResult2.urls.length).to.be.eq(testObject_2.url.length);
+    expect(testResult2.urls[0].hostname).to.be.eq('127.0.0.1');
+    expect(testResult2.urls[1].hostname).to.be.eq('123.1.1.1');
+
+
+
+  });
+
+  it("Should resolve properly as expected", function () {
+
+    var proxy = new Redbird(opts), resolver = function (host, url) {
+      return url.match(/\/ignore/i) ? null : 'http://172.12.0.1/home'
+    }, result;
+
+    resolver.priority = 1;
+
+    proxy.register('mysite.example.com', 'http://127.0.0.1:9999');
+    proxy.addResolver(resolver);
+
+    result = proxy.resolve('randomsite.example.com', '/anywhere');
+
+    //must match the resolver
+    expect(result).to.not.be.null;
+    expect(result).to.not.be.undefined;
+    expect(result.urls.length).to.be.above(0);
+    expect(result.urls[0].hostname).to.be.eq('172.12.0.1');
+
+    //expect route to match resolver even though it matches registered address
+    result = proxy.resolve('mysite.example.com', '/somewhere');
+    expect(result.urls[0].hostname).to.be.eq('172.12.0.1');
+
+    //use default resolver, as custom resolver should ignore input.
+    result = proxy.resolve('mysite.example.com', '/ignore');
+    expect(result.urls[0].hostname).to.be.eq('127.0.0.1');
+
+
+    //make custom resolver low priority and test.
+    //result should match default resolver
+    resolver.priority = -1;
+    proxy.addResolver(resolver);
+    result = proxy.resolve('mysite.example.com', '/somewhere');
+    expect(result.urls[0].hostname).to.be.eq('127.0.0.1');
+
+
+    //both custom and default resolvers should ignore
+    result = proxy.resolve('somesite.example.com', '/ignore');
+    expect(result).to.be.undefined;
+
+    proxy.removeResolver(resolver);
+    //for path-based routing
+    //when resolver path doesn't match that of url, skip
+
+    resolver = function () {
+      return {
+        path: '/notme',
+        url: 'http://172.12.0.1/home'
+      }
+    };
+    resolver.priority = 1;
+    proxy.addResolver(resolver);
+
+    result = proxy.resolve('somesite.example.com', '/notme');
+    expect(result).to.not.be.undefined;
+    expect(result.urls[0].hostname).to.be.eq('172.12.0.1');
+
+    result = proxy.resolve('somesite.example.com', '/notme/somewhere');
+    expect(result.urls[0].hostname).to.be.eq('172.12.0.1');
+
+    result = proxy.resolve('somesite.example.com', '/itsme/somewhere');
+    expect(result).to.be.undefined;
+
+
+    proxy.close();
+  });
+
+});


### PR DESCRIPTION
Added custom resolvers. quite similar to middlewares. They help you customize how traffic to upstream is routed.

Snippets I added to README.md

##Custom Resolvers

With custom resolvers, you can decide how the proxy server handles request. Custom resolvers allow you to extend redbird considerably. With custom resolvers, you can perform the following:

- Do path-based routing
- Do wildcard domain routing.
- Use variable upstream servers based on availability, for example in conjunction with Etcd or any other service discovery platform.
- And more.

Resolvers should be:

  1. Be invokable function. The `this` context of such function is the Redbird Proxy object. The resolver function takes in two parameters : `host` and `url`
  2. Have a priority, resolvers with higher priorities are called before those of lower priorities. The default resolver, has a priority of 0.
  3. A resolver should return a route object or a string when matches it matches the parameters passed in. If string is returned, then it must be a valid upstream URL, if object, then the object must conform to the following:

```
  {
     url: string or array of string [required], when array, the urls will be load-balanced across.
     path: path prefix for route, [optional], defaults to '/',
     opts: {} //redbird target options, see Redbird.register() [optional],
  }
```

### Defining Resolvers

Resolvers can be defined when initializing the proxy object with the `resolvers` parameter. An example is below:

```javascript
 //for every URL path that starts with /api/, send request to upstream API service
 var customResolver1 = function(host, url) {
   if(/^\/api\//.test(url)){
      return 'http://127.0.0.1:8888';
   }
 };

 //assign high priority
 customResolver1.priority = 100;

 var proxy = new require('redbird')({
    port: 8080,
    resolvers: [
    customResolver1,
    //uses the same priority as default resolver, so will be called after default resolver
    function(host, url) {
      if(/\.example\.com/.test(host)){
        return 'http://127.0.0.1:9999'
      }
    }]
 })

```

### Adding and Removing Resolvers at Runtime.

You can add or remove resolvers at runtime, this is useful in situations where your upstream is tied to a service discovery service system.

```javascript
var topPriority = function(host, url) {
  return /app\.example\.com/.test(host) ? {
    //load balanced
    url: [
    'http://127.0.0.1:8000',
    'http://128.0.1.1:9999'
   ]
  } : null;
};

topPriority.priority = 200;
proxy.addResolver(topPriority);


//remove top priority after 10 minutes,
setTimeout(function() {
  proxy.removeResolver(topPriority);
}, 600000);