### PR TITLE
Change the way filters are passed to dolphin to detect running containers

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -50,7 +50,7 @@ function DockerModule(redbird, url) {
     //  Fetch all running containers and register them if
     //  necessary.
     //
-    dolphin.containers({ filters: '{"status":["running"]}' }).then(function (containers) {
+    dolphin.containers({ filters: {status:["running"]} }).then(function (containers) {
       for (var i = 0; i < containers.length; i++) {
         var container = containers[i];
         registerIfNeeded(container.Image, container.Id, container.Names);


### PR DESCRIPTION
When using the docker module, I had this error: 

    filters[key] = [filters[key].toString()];
                 ^

TypeError: Cannot assign to read only property '0' of string '{"status":["running"]}'
    at /Users/joelgrenon/Projects/lifepulz/gateway/node_modules/dolphin/index.js:263:18
    at Array.forEach (native)
    at filtersToJSON (/Users/joelgrenon/Projects/lifepulz/gateway/node_modules/dolphin/index.js:262:8)
    at buildUrl (/Users/joelgrenon/Projects/lifepulz/gateway/node_modules/dolphin/index.js:253:23)
    at Dolphin._request (/Users/joelgrenon/Projects/lifepulz/gateway/node_modules/dolphin/index.js:216:14)
    at Dolphin._get (/Users/joelgrenon/Projects/lifepulz/gateway/node_modules/dolphin/index.js:201:15)
    at Dolphin.containers (/Users/joelgrenon/Projects/lifepulz/gateway/node_modules/dolphin/index.js:95:15)

After a few minutes, I found that filters needed to be passed as a hash instead as a string. I made the change and everything works better.
