### PR TITLE
This adds ability to create multiple HTTPS servers bound to own IP addresses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,45 @@ redbird.register('tutorial.com', 'https://172.60.80.2:8083', {
 
 ```
 
+Edge case scenario: you have HTTPS server with two IP  addresses assigned and you clients are old software without SNI support. In this case on both IP addresses they will receive the same fallback certificate. I.e. some of domains will have wrong certificate. To handle this case you can create two HTTPS servers each bound to its own IP address and serving appropriate certificate.
+
+```js
+var redbird = new require('redbird')({
+	port: 8080,
+
+	// Specify filenames to default SSL certificates (in case SNI is not supported by the
+	// user's browser)
+	ssl: [
+		{
+			port: 443,
+			ip: '123.45.67.10',  // assigned to tutorial.com
+			key: 'certs/tutorial.key',
+			cert: 'certs/tutorial.crt',
+		},
+		{
+			port: 443,
+			ip: '123.45.67.11', // assigned to my-other-domain.com
+			key: 'certs/my-other-domain.key',
+			cert: 'certs/my-other-domain.crt',
+		}				
+	]
+});
+
+// These certificates will be served if SNI is supported
+redbird.register('tutorial.com', 'http://192.168.0.10:8001', {
+	ssl: {
+		key: 'certs/tutorial.key',
+		cert: 'certs/tutorial.crt',
+	}
+});
+redbird.register('my-other-domain.com', 'http://192.168.0.12:8001', {
+	ssl: {
+		key: 'certs/my-other-domain.key',
+		cert: 'certs/my-other-domain.crt',
+	}
+});
+```
+
 ##Docker support
 If you use docker, you can tell Redbird to automatically register routes based on image
 names. You register your image name and then every time a container starts from that image,

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ redbird.register('tutorial.com', 'https://172.60.80.2:8083', {
 
 ```
 
-Edge case scenario: you have HTTPS server with two IP  addresses assigned and you clients are old software without SNI support. In this case on both IP addresses they will receive the same fallback certificate. I.e. some of domains will have wrong certificate. To handle this case you can create two HTTPS servers each bound to its own IP address and serving appropriate certificate.
+Edge case scenario: you have an HTTPS server with two IP addresses assigned to it and your clients use old software without SNI support. In this case, both IP addresses will receive the same fallback certificate. I.e. some of the domains will get a wrong certificate. To handle this case you can create two HTTPS servers each one bound to its own IP address and serving the appropriate certificate.
 
 ```js
 var redbird = new require('redbird')({

--- a/lib/letsencrypt.js
+++ b/lib/letsencrypt.js
@@ -99,7 +99,7 @@ function getCertificates(domain, email, production, renew, logger){
     }
 
     // Register Certificate manually
-    logger.info('Manually registering certificate for %s', domain);
+    logger && logger.info('Manually registering certificate for %s', domain);
     return le.register({
       domains: [domain],
       email: email,
@@ -107,7 +107,7 @@ function getCertificates(domain, email, production, renew, logger){
       rsaKeySize: 2048,                                       // 2048 or higher
       challengeType: 'http-01'                                // http-01, tls-sni-01, or dns-01
     }).catch(function (err) {
-      logger.error(err, 'Error registering LetsEncrypt certificates');
+      logger && logger.error(err, 'Error registering LetsEncrypt certificates');
     });
   });
 }

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -661,7 +661,8 @@ ReverseProxy.prototype.notFound = function (callback) {
 function redirectToHttps(req, res, target, ssl, log) {
   req.url = req._url || req.url; // Get the original url since we are going to redirect.
 
-  var hostname = req.headers.host.split(':')[0] + ':' + (ssl.redirectPort || ssl.port);
+  var targetPort = ssl.redirectPort || ssl.port;
+  var hostname = req.headers.host.split(':')[0] + ( targetPort ? ':'+targetPort : '' );
   var url = 'https://' + path.join(hostname, req.url);
   log && log.info('Redirecting %s to %s', path.join(req.headers.host, req.url), url);
   //

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -217,7 +217,9 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
   var _this = this;
   var https;
 
-  var certs = this.certs = {};
+  this.certs = this.certs || {};
+
+  var certs = this.certs;
 
   var ssl = {
     SNICallback: function (hostname, cb) {
@@ -244,7 +246,7 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
 
   if (sslOpts.http2) {
     https = require('spdy');
-    if(_.isObject(opts.http2)){
+    if(_.isObject(sslOpts.http2)){
       sslOpts.spdy = sslOpts.http2;
     }
   } else {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -407,10 +407,10 @@ ReverseProxy.prototype.updateCertificates = function (domain, email, production,
       var renewTime = (certs.expiresAt - Date.now()) - timeBeforeExpiration;
 
       renewTime = renewTime > 0 ? renewTime : 60 * 1000 * 60;
-      _this.log & _this.log.info('Renewal of %s in %s days', domain, Math.floor(renewTime / ONE_DAY));
+      _this.log && _this.log.info('Renewal of %s in %s days', domain, Math.floor(renewTime / ONE_DAY));
 
       function renewCertificate() {
-        _this.log & _this.log.info('Renewing letscrypt certificates for %s', domain);
+        _this.log && _this.log.info('Renewing letscrypt certificates for %s', domain);
         _this.updateCertificates(domain, email, production, true);
       }
 
@@ -419,7 +419,7 @@ ReverseProxy.prototype.updateCertificates = function (domain, email, production,
       //
       // TODO: Try again, but we need an exponential backof to avoid getting banned.
       //
-      _this.log & _this.log.info('Could not get any certs for %s', domain);
+      _this.log && _this.log.info('Could not get any certs for %s', domain);
     }
   }, function (err) {
     console.error('Error getting LetsEncrypt certificates', err);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -662,7 +662,7 @@ function redirectToHttps(req, res, target, ssl, log) {
   req.url = req._url || req.url; // Get the original url since we are going to redirect.
 
   var targetPort = ssl.redirectPort || ssl.port;
-  var hostname = req.headers.host.split(':')[0] + ( targetPort ? ':'+targetPort : '' );
+  var hostname = req.headers.host.split(':')[0] + ( targetPort ? ':' + targetPort : '' );
   var url = 'https://' + path.join(hostname, req.url);
   log && log.info('Redirecting %s to %s', path.join(req.headers.host, req.url), url);
   //

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -105,13 +105,13 @@ function ReverseProxy(opts) {
     // Optionally create an https proxy server.
     //
     if (opts.ssl) {
-		if (_.isArray(opts.ssl)) {
-			opts.ssl.forEach(function(sslOpts){
-				_this.setupHttpsProxy(proxy, websocketsUpgrade, log, sslOpts);
-			})
-		} else {
-			this.setupHttpsProxy(proxy, websocketsUpgrade, log, opts.ssl);
-		}
+      if (_.isArray(opts.ssl)) {
+        opts.ssl.forEach(function(sslOpts){
+          _this.setupHttpsProxy(proxy, websocketsUpgrade, log, sslOpts);
+        })
+      } else {
+        this.setupHttpsProxy(proxy, websocketsUpgrade, log, opts.ssl);
+      }
     }
 
     //

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -105,7 +105,13 @@ function ReverseProxy(opts) {
     // Optionally create an https proxy server.
     //
     if (opts.ssl) {
-      this.setupHttpsProxy(proxy, websocketsUpgrade, log, opts);
+		if (_.isArray(opts.ssl)) {
+			opts.ssl.forEach(function(sslOpts){
+				_this.setupHttpsProxy(proxy, websocketsUpgrade, log, sslOpts);
+			})
+		} else {
+			this.setupHttpsProxy(proxy, websocketsUpgrade, log, opts.ssl);
+		}
     }
 
     //
@@ -136,7 +142,6 @@ function ReverseProxy(opts) {
     // Send a 500 http status if headers have been sent
     //
 
-    console.log(err);
     if (err.code === 'ECONNREFUSED') {
       res.writeHead && res.writeHead(502);
     } else if (!res.headersSent) {
@@ -208,7 +213,7 @@ ReverseProxy.prototype.setupLetsencrypt = function (log, opts) {
   this.addResolver(challengeResolver);
 }
 
-ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log, opts){
+ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log, sslOpts){
   var _this = this;
   var https;
 
@@ -225,22 +230,22 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
     //
     // Default certs for clients that do not support SNI.
     //
-    key: getCertData(opts.ssl.key),
-    cert: getCertData(opts.ssl.cert)
+    key: getCertData(sslOpts.key),
+    cert: getCertData(sslOpts.cert)
   };
 
-  if (opts.ssl.ca) {
-    ssl.ca = getCertData(opts.ssl.ca, true);
+  if (sslOpts.ca) {
+    ssl.ca = getCertData(sslOpts.ca, true);
   }
 
-  if (opts.ssl.opts) {
-    ssl = _.defaults(ssl, opts.ssl.opts);
+  if (sslOpts.opts) {
+    ssl = _.defaults(ssl, sslOpts.opts);
   }
 
-  if (opts.ssl.http2) {
+  if (sslOpts.http2) {
     https = require('spdy');
     if(_.isObject(opts.http2)){
-      opts.ssl.spdy = opts.ssl.http2;
+      sslOpts.spdy = sslOpts.http2;
     }
   } else {
     https = require('https');
@@ -268,8 +273,8 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
     log && log.error(err, 'HTTPS Client  Error');
   });
 
-  log && log.info('Listening to HTTPS requests on port %s', opts.ssl.port);
-  httpsServer.listen(opts.ssl.port);
+  log && log.info('Listening to HTTPS requests on port %s', sslOpts.port);
+  httpsServer.listen(sslOpts.port, sslOpts.ip);
 }
 
 ReverseProxy.prototype.addResolver = function (resolver) {


### PR DESCRIPTION
This PR adds an ability to create multiple HTTPS servers each bound to own IP address. 
This is useful if you need to support old clients without SNI. See README for example.

Also this PR adds handling of an edge case when logging is turned off and logger is not defined.