### PR TITLE
Use `X-Forwarded-Host` header for source determination (if desired)

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -624,6 +624,9 @@ ReverseProxy.prototype.close = function () {
 // Helpers
 //
 function getSource(req) {
+  if (req.headers['x-forwarded-host']) {
+    return req.headers['x-forwarded-host'].split(':')[0];
+  }
   if (req.headers.host) {
     return req.headers.host.split(':')[0];
   }

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -127,7 +127,7 @@ function ReverseProxy(opts) {
   }
 
   function websocketsUpgrade(req, socket, head) {
-    var src = getSource(req);
+    var src = this._getSource(req);
     var target = _this._getTarget(src, req);
     log && log.info({ headers: req.headers, target: target }, 'upgrade to websockets');
     if (target) {
@@ -166,7 +166,7 @@ function ReverseProxy(opts) {
 ReverseProxy.prototype.setupHttpProxy = function (proxy, websocketsUpgrade, log, opts) {
   var _this = this;
   var server = this.server = http.createServer(function (req, res) {
-    var src = getSource(req);
+    var src = _this._getSource(req);
     var target = _this._getTarget(src, req);
     if (target){
       if (shouldRedirectToHttps(_this.certs, src, target, _this)) {
@@ -257,7 +257,7 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
 
   var httpsServer = this.httpsServer = https.createServer(ssl, function (req, res) {
 
-    var src = getSource(req);
+    var src = this._getSource(req);
 
     var target = _this._getTarget(src, req);
     if (target) {
@@ -611,6 +611,15 @@ ReverseProxy.prototype._getTarget = function (src, req) {
   return target;
 };
 
+ReverseProxy.prototype._getSource = function (req) {
+  if (this.opts.preferForwardedHost === true && req.headers['x-forwarded-host']) {
+    return req.headers['x-forwarded-host'].split(':')[0];
+  }
+  if (req.headers.host) {
+    return req.headers.host.split(':')[0];
+  }
+}
+
 ReverseProxy.prototype.close = function () {
   try {
     this.server.close();
@@ -623,15 +632,6 @@ ReverseProxy.prototype.close = function () {
 //
 // Helpers
 //
-function getSource(req) {
-  if (req.headers['x-forwarded-host']) {
-    return req.headers['x-forwarded-host'].split(':')[0];
-  }
-  if (req.headers.host) {
-    return req.headers.host.split(':')[0];
-  }
-}
-
 /**
   Routing table structure. An object with hostname as key, and an array as value.
   The array has one element per path associated to the given hostname.

--- a/test/test_hostheader.js
+++ b/test/test_hostheader.js
@@ -98,6 +98,34 @@ describe("Target with a hostname", function(){
 	})
 })
 
+describe("Request with forwarded host header", function () {
+	it("should prefer forwarded hostname if desired", function () {
+		var redbird = Redbird({
+			bunyan: false,
+			preferForwardedHost: true
+		});
+
+		expect(redbird.routing).to.be.an("object");
+		var req = { headers: {host: '127.0.0.1', "x-forwarded-host": "subdomain.example.com"} }
+		
+		var source = redbird._getSource(req);
+		expect(source).to.be.eql('subdomain.example.com')
+
+		redbird.close();
+	});
+
+		it("should use original host if not further specified", function () {
+		var redbird = Redbird(opts);
+
+		expect(redbird.routing).to.be.an("object");
+		var req = { headers: { host: '127.0.0.1', "x-forwarded-host": "subdomain.example.com"} }
+		
+		var source = redbird._getSource(req);
+		expect(source).to.be.eql('127.0.0.1')
+
+		redbird.close();
+	});
+});
 
 function testServer(){
 	return new Promise(function(resolve, reject){


### PR DESCRIPTION
I'm having the following setup:

```
Cloudflare -> Nginx -> Redbird
```

As the Redbird App is not reachable from the public internet I'm redirecting request using a Nginx LB. This sets a `X-Forwarded-Host` header to tell the Redbird instance how to handle the requests. With the current setup this doesn't work as Redbird doesn't respect those requests. I've added functionality so Redbird is able to opt in for handling this header if 

```
{
  preferFordwardedHeader: true
}
```

is being set.