### PR TITLE
Added the ability to set the host of the server

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -119,7 +119,7 @@ function ReverseProxy(opts) {
     //
     var server = this.setupHttpProxy(proxy, websocketsUpgrade, log, opts);
 
-    server.listen(opts.port);
+    server.listen(opts.port, opts.host);
 
     proxy.on('error', handleProxyError);
 


### PR DESCRIPTION
Options now allows `.host` to indicate the IP to listen on. See line 122 and here: 

https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback