### PR TITLE
Added basic CORS support to redbird.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -114,11 +114,22 @@ function ReverseProxy(opts) {
       }
     }
 
-    //
-    // Plain HTTP Proxy
-    //
+
     var server = this.setupHttpProxy(proxy, websocketsUpgrade, log, opts);
 
+    if(_.isEmpty(opts['cors']) === false && opts['cors']['allow'] === true){
+        server.use(function(req, res, next) {
+            res.header("Access-Control-Allow-Origin", "*");
+            res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+            next();
+        });
+
+    }
+
+
+      //
+      // Plain HTTP Proxy
+      //
     server.listen(opts.port, opts.host);
 
     proxy.on('error', handleProxyError);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -117,14 +117,7 @@ function ReverseProxy(opts) {
 
     var server = this.setupHttpProxy(proxy, websocketsUpgrade, log, opts);
 
-    if(_.isEmpty(opts['cors']) === false && opts['cors']['allow'] === true){
-        server.use(function(req, res, next) {
-            res.header("Access-Control-Allow-Origin", "*");
-            res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-            next();
-        });
 
-    }
 
 
       //
@@ -199,6 +192,15 @@ ReverseProxy.prototype.setupHttpProxy = function (proxy, websocketsUpgrade, log,
   server.on('error', function (err) {
     log && log.error(err, 'Server Error');
   });
+
+    if(_.isEmpty(opts['cors']) === false && opts['cors']['allow'] === true){
+        server.use(function(req, res, next) {
+            res.header("Access-Control-Allow-Origin", "*");
+            res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+            next();
+        });
+
+    }
 
   return server;
 }
@@ -288,7 +290,17 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
     log && log.error(err, 'HTTPS Client  Error');
   });
 
-  log && log.info('Listening to HTTPS requests on port %s', sslOpts.port);
+
+    if(_.isEmpty(opts['cors']) === false && opts['cors']['allow'] === true){
+        httpsServer.use(function(req, res, next) {
+            res.header("Access-Control-Allow-Origin", "*");
+            res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+            next();
+        });
+
+    }
+
+    log && log.info('Listening to HTTPS requests on port %s', sslOpts.port);
   httpsServer.listen(sslOpts.port, sslOpts.ip);
 }
 


### PR DESCRIPTION
added opts['cors'] and opts['cors'] is an object.

set opts['cors']['allow'] = true ; to enable Cross Orign Resource Sharing on your server.

NOTE: For now, all the requests are accepted.

ability to accept specific / filter the requests will be added soon.