### PR TITLE
Added basic CORS support for HTTP and HTTPS servers.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -119,6 +119,8 @@ function ReverseProxy(opts) {
     //
     var server = this.setupHttpProxy(proxy, websocketsUpgrade, log, opts);
 
+    server = allowCORS(server);
+
     server.listen(opts.port, opts.host);
 
     proxy.on('error', handleProxyError);
@@ -278,7 +280,10 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
   });
 
   log && log.info('Listening to HTTPS requests on port %s', sslOpts.port);
+
+  httpsServer = allowCORS(httpsServer);
   httpsServer.listen(sslOpts.port, sslOpts.ip);
+
 }
 
 ReverseProxy.prototype.addResolver = function (resolver) {
@@ -772,3 +777,18 @@ function setHttp(link) {
 }
 
 module.exports = ReverseProxy;
+
+
+function allowCORS(objServer){
+
+    if(_.isEmpty(opts['cors']) === false && opts['cors']['allow'] === true){
+        objServer.use(function(req, res, next) {
+            res.header("Access-Control-Allow-Origin", "*");
+            res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+            next();
+        });
+    }
+
+    return objServer;
+
+}


### PR DESCRIPTION
Just include the opts['cors'] key while creating the server.
value of opts['cors'] must be an object.
Set opts['cors']['allow'] = true;

For now, it will allow request from any orign.

Ability to filter requests or extend the functionality etc.. will be added further.

NOTE: If the opts['cors']['allow'] = true is not set as per above instructions, it just will ignore the CORS code and would produce NO ERROR.