### PR TITLE
Added CORS support for both HTTP and HTTPS servers.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -167,6 +167,9 @@ ReverseProxy.prototype.setupHttpProxy = function (proxy, websocketsUpgrade, log,
   var _this = this;
   var server = this.server = http.createServer(function (req, res) {
     var src = _this._getSource(req);
+
+    res = allowCORS(res, opts);
+
     var target = _this._getTarget(src, req);
     if (target){
       if (shouldRedirectToHttps(_this.certs, src, target, _this)) {
@@ -189,7 +192,7 @@ ReverseProxy.prototype.setupHttpProxy = function (proxy, websocketsUpgrade, log,
     log && log.error(err, 'Server Error');
   });
 
-  server = allowCORS(server, opts);
+
 
   return server;
 }
@@ -261,6 +264,8 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
 
     var src = this._getSource(req);
 
+    res = allowCORS(res, opts);
+
     var target = _this._getTarget(src, req);
     if (target) {
       proxy.web(req, res, { target: target });
@@ -268,8 +273,6 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
       respondNotFound(req, res);
     }
   });
-
-  httpsServer = allowCORS(httpsServer,sslOpts);
 
   httpsServer.on('upgrade', websocketsUpgrade);
 
@@ -421,7 +424,8 @@ ReverseProxy.prototype.updateCertificates = function (domain, email, production,
 
       _this.log && _this.log.info('Renewal of %s in %s days', domain, Math.floor(renewTime / ONE_DAY));
 
-      function renewCertificate() {
+      //noinspection JSAnnotator
+        function renewCertificate() {
         _this.log && _this.log.info('Renewing letscrypt certificates for %s', domain);
         _this.updateCertificates(domain, email, production, renewWithin, true);
       }
@@ -781,15 +785,14 @@ function setHttp(link) {
 
 // To allow CORS
 
-function allowCORS(objServer, opts){
+function allowCORS(res, opts){
     if(_.isEmpty(opts['cors']) === false && opts['cors']['allow'] && opts['cors']['allow'] === true){
-        objServer.use(function(req, res, next) {
-            res.header("Access-Control-Allow-Origin", "*");
-            res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-            next();
-        });
+
+        res.setHeader("Access-Control-Allow-Origin", "*");
+        res.setHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+
     }
-    return objServer;
+    return res;
 }
 
 module.exports = ReverseProxy;

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -189,6 +189,8 @@ ReverseProxy.prototype.setupHttpProxy = function (proxy, websocketsUpgrade, log,
     log && log.error(err, 'Server Error');
   });
 
+  server = allowCORS(server, opts);
+
   return server;
 }
 
@@ -267,6 +269,8 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
     }
   });
 
+  httpsServer = allowCORS(httpsServer,sslOpts);
+
   httpsServer.on('upgrade', websocketsUpgrade);
 
   httpsServer.on('error', function (err) {
@@ -278,6 +282,9 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
   });
 
   log && log.info('Listening to HTTPS requests on port %s', sslOpts.port);
+
+
+
   httpsServer.listen(sslOpts.port, sslOpts.ip);
 }
 
@@ -769,6 +776,20 @@ function setHttp(link) {
     link = 'http://' + link;
   }
   return link;
+}
+
+
+// To allow CORS
+
+function allowCORS(objServer, opts){
+    if(_.isEmpty(opts['cors']) === false && opts['cors']['allow'] && opts['cors']['allow'] === true){
+        objServer.use(function(req, res, next) {
+            res.header("Access-Control-Allow-Origin", "*");
+            res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+            next();
+        });
+    }
+    return objServer;
 }
 
 module.exports = ReverseProxy;


### PR DESCRIPTION
while creating ```http server/ https server```, opts / sslOpts are already sent as parameters.

add ```opts['cors']``` object to the opts / sslOpts.

```opts['cors']``` needs the key ```opts['cors']['allow'] = true```

If ```opts['cors']['allow']``` is not sent in specified format, it will just ignore it and work as if no CORS is added.

For now, all requests originating from any source would be allowed.

Ability to filter the requests can be added in future.