### PR TITLE
fixed: GET / on LetsEncrypt port crashes proxy

### DIFF
--- a/lib/letsencrypt.js
+++ b/lib/letsencrypt.js
@@ -38,17 +38,25 @@ function init(certPath, port, logger){
 
     webrootPath: webrootPath,
     debug: false
-  }
+  };
 
   // we need to proxy for example: 'example.com/.well-known/acme-challenge' -> 'localhost:port/example.com/'
   http.createServer(function (req, res){
     var uri = url.parse(req.url).pathname;
     var filename = path.join(certPath, uri);
+    var isForbiddenPath = uri.length < 3 || filename.indexOf(certPath) !== 0;
+
+    if (isForbiddenPath) {
+      logger && logger.info('Forbidden request on LetsEncrypt port %s: %s', port, filename);
+      res.writeHead(403);
+      res.end();
+      return;
+    }
 
     logger && logger.info('LetsEncrypt CA trying to validate challenge %s', filename);
 
-    fs.exists(filename, function(exists) {
-      if (!exists){
+    fs.stat(filename, function(err, stats) {
+      if (err || !stats.isFile()) {
         res.writeHead(404, {"Content-Type": "text/plain"});
         res.write("404 Not Found\n");
         res.end();
@@ -58,6 +66,7 @@ function init(certPath, port, logger){
       res.writeHead(200);
       fs.createReadStream(filename, "binary").pipe(res);
     });
+
   }).listen(port);
 }
 


### PR DESCRIPTION
When using LetsEncrypt in zero config setup, random HTTP requests to the LetsEncrypt port can crash the proxy due to improper file checking.

`let proxy = require('redbird')({
        port: 8080,
        xfwd: true,
        ssl: {
                port: 8443
        },
        letsencrypt: {
                path: __dirname + '/certs/',
                port: 3000
        }
});`

`$ curl localhost:3000`

=> Crashes the server with "Error: EISDIR: illegal operation on a directory, read" due to fs.createReadStream on the certs/ directory itself.

I replaced the deprecated fs.exists-call with fs.stat() and a file-check. 
Also letting requests fail silently (403) that obviously do not come from LetsEncrypt.