### PR TITLE
Support for passing in your own versions of the http, https and spdy …

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -169,7 +169,8 @@ function ReverseProxy(opts) {
 
 ReverseProxy.prototype.setupHttpProxy = function (proxy, websocketsUpgrade, log, opts) {
   var _this = this;
-  var server = this.server = http.createServer(function (req, res) {
+  var httpServerModule = opts.httpServerModel || http;
+  var server = this.server = httpServerModule.createServer(function (req, res) {
     var src = _this._getSource(req);
     var target = _this._getTarget(src, req);
     if (target){
@@ -251,12 +252,12 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
   }
 
   if (sslOpts.http2) {
-    https = require('spdy');
+    https = sslOpts.spdyServerModule || require('spdy');
     if(_.isObject(sslOpts.http2)){
       sslOpts.spdy = sslOpts.http2;
     }
   } else {
-    https = require('https');
+    https = sslOpts.httpsServerModel || require('https');
   }
 
   var httpsServer = this.httpsServer = https.createServer(ssl, function (req, res) {


### PR DESCRIPTION
…modules.

This is useful if you want to use a module like findhit-proxywrap to enable support for the PROXY protocol:
http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt

 - which is used in tools like HA-Proxy, or optionally in Amazon ELB load balancers to pass the original
   client IP when proxying TCP connections.