### PR TITLE
Support for passing in your own versions of the http server modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,8 @@ __Arguments__
 ---------------------------------------
 
 <a name="register"/>
-#### Redbird##register(src, target, opts)
+
+#### Redbird::register(src, target, opts)
 
 Register a new route. As soon as this method is called, the proxy will
 start routing the sources to the given targets.
@@ -512,7 +513,8 @@ __Arguments__
 ---------------------------------------
 
 <a name="unregister"/>
-#### Redbird##unregister(src, [target])
+
+#### Redbird.unregister(src, [target])
 
  Unregisters a route. After calling this method, the given route will not
  be proxied anymore.
@@ -528,7 +530,8 @@ __Arguments__
 ---------------------------------------
 
 <a name="notFound"/>
-#### Redbird##notFound(callback)
+
+#### Redbird.notFound(callback)
 
  Gives Redbird a callback function with two parameters, the HTTP request
  and response objects, respectively, which will be called when a proxy route is
@@ -552,7 +555,8 @@ __Arguments__
 ---------------------------------------
 
 <a name="close"/>
-#### Redbird##close()
+
+#### Redbird.close()
 
  Close the proxy stopping all the incoming connections.
 

--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ var proxy = require('redbird')(opts);
 [close](#close)
 
 <a name="redbird"/>
+
 ### Redbird(opts)
 
 This is the Proxy constructor. Creates a new Proxy and starts listening to

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -169,7 +169,7 @@ function ReverseProxy(opts) {
 
 ReverseProxy.prototype.setupHttpProxy = function (proxy, websocketsUpgrade, log, opts) {
   var _this = this;
-  var httpServerModule = opts.httpServerModule || http;
+  var httpServerModule = opts.serverModule || http;
   var server = this.server = httpServerModule.createServer(function (req, res) {
     var src = _this._getSource(req);
     var target = _this._getTarget(src, req);
@@ -252,12 +252,12 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
   }
 
   if (sslOpts.http2) {
-    https = sslOpts.spdyServerModule || require('spdy');
+    https = sslOpts.serverModule || require('spdy');
     if(_.isObject(sslOpts.http2)){
       sslOpts.spdy = sslOpts.http2;
     }
   } else {
-    https = sslOpts.httpsServerModule || require('https');
+    https = sslOpts.serverModule || require('https');
   }
 
   var httpsServer = this.httpsServer = https.createServer(ssl, function (req, res) {


### PR DESCRIPTION
This is useful if you want to use a module like findhit-proxywrap to enable support for the PROXY protocol:
http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt

PROXY protocol is used in tools like HA-Proxy, and can be optionally enabled in Amazon ELB load balancers to pass the original client IP when proxying TCP connections (similar to an X-Forwarded-For header, but for raw TCP).  This is useful if you want to run redbird on AWS behind an ELB load balancer, but have redbird terminate any HTTPS connections so you can have SNI/Let's Encrypt/HTTP2support.  Redbird will see the client's IP address rather than the load-balancer's, and pass this through in an X-Forwarded-For header.

An example of this is

````
//Options for proxywrap. This means the proxy will also respond to regular HTTP requests without PROXY information as well.
proxy_opts = {strict: false}; 
proxyWrap = require('findhit-proxywrap');
var opts = {
    port: process.env.HTTP_PORT,
    httpServerModule = proxyWrap.proxy( require('http'), proxy_opts),
    ssl: {
        http2: true,
        httpsServerModule = proxyWrap.proxy( require('http'), proxy_opts),
        spdyServerModule = proxyWrap.proxy(require('spdy').server, proxy_opts),
        port: process.env.HTTPS_PORT,
    }
}

// Create the proxy
var proxy = require('redbird')(opts);
````

Then configure PROXY support in the ELB http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html, and configure a TCP (rather than HTTPS) listener on port 443 of the ELB