### PR TITLE
Add async support to custom resolvers.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -14,7 +14,8 @@ var
   LRUCache = require("lru-cache"),
   routeCache = LRUCache({ max: 5000 }),
   safe = require('safetimeout'),
-  letsencrypt = require('./letsencrypt.js');
+  letsencrypt = require('./letsencrypt.js'),
+  Promise = require('bluebird');
 
 var ONE_DAY = 60 * 60 * 24 * 1000;
 var ONE_MONTH = ONE_DAY * 30;
@@ -132,13 +133,14 @@ function ReverseProxy(opts) {
 
   function websocketsUpgrade(req, socket, head) {
     var src = _this._getSource(req);
-    var target = _this._getTarget(src, req);
-    log && log.info({ headers: req.headers, target: target }, 'upgrade to websockets');
-    if (target) {
-      proxy.ws(req, socket, head, { target: target });
-    } else {
-      respondNotFound(req, socket);
-    }
+    _this._getTarget(src, req).then(function (target) {
+      log && log.info({ headers: req.headers, target: target }, 'upgrade to websockets');
+      if (target) {
+        proxy.ws(req, socket, head, { target: target });
+      } else {
+        respondNotFound(req, socket);
+      }
+    });
   }
 
   function handleProxyError(err, req, res) {
@@ -172,16 +174,17 @@ ReverseProxy.prototype.setupHttpProxy = function (proxy, websocketsUpgrade, log,
   var httpServerModule = opts.serverModule || http;
   var server = this.server = httpServerModule.createServer(function (req, res) {
     var src = _this._getSource(req);
-    var target = _this._getTarget(src, req);
-    if (target){
-      if (shouldRedirectToHttps(_this.certs, src, target, _this)) {
-        redirectToHttps(req, res, target, opts.ssl, log);
+    _this._getTarget(src, req).bind(_this).then(function (target) {
+      if (target){
+        if (shouldRedirectToHttps(_this.certs, src, target, _this)) {
+          redirectToHttps(req, res, target, opts.ssl, log);
+        } else {
+          proxy.web(req, res, { target: target });
+        }
       } else {
-        proxy.web(req, res, { target: target });
+        respondNotFound(req, res);
       }
-    } else {
-      respondNotFound(req, res);
-    }
+    });
   });
 
   //
@@ -264,12 +267,13 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
 
     var src = _this._getSource(req);
 
-    var target = _this._getTarget(src, req);
-    if (target) {
-      proxy.web(req, res, { target: target });
-    } else {
-      respondNotFound(req, res);
-    }
+    _this._getTarget(src, req).then(function (target) {
+      if (target) {
+        proxy.web(req, res, { target: target });
+      } else {
+        respondNotFound(req, res);
+      }
+    });
   });
 
   httpsServer.on('upgrade', websocketsUpgrade);
@@ -518,18 +522,20 @@ ReverseProxy.prototype._defaultResolver.priority = 0;
  * @returns {*}
  */
 ReverseProxy.prototype.resolve = function (host, url, req) {
-  var route;
+  var resolvedValue;
 
   host = host && host.toLowerCase();
   for (var i = 0; i < this.resolvers.length; i++) {
-    route = this.resolvers[i].call(this, host, url, req);
-    if (route && (route = ReverseProxy.buildRoute(route))) {
-      // ensure resolved route has path that prefixes URL
-      // no need to check for native routes.
-      if (!route.isResolved || route.path === '/' || startsWith(url, route.path)) {
-        return route;
+    resolvedValue = this.resolvers[i].call(this, host, url, req);
+    return Promise.resolve(resolvedValue).then(function (route) {
+      if (route && (route = ReverseProxy.buildRoute(route))) {
+        // ensure resolved route has path that prefixes URL
+        // no need to check for native routes.
+        if (!route.isResolved || route.path === '/' || startsWith(url, route.path)) {
+          return route;
+        }
       }
-    }
+    });
   }
 };
 
@@ -570,50 +576,51 @@ ReverseProxy.buildRoute = function (route) {
 
 ReverseProxy.prototype._getTarget = function (src, req) {
   var url = req.url;
-  var route = this.resolve(src, url, req);
 
-  if (!route) {
-    this.log && this.log.warn({ src: src, url: url }, 'no valid route found for given source');
-    return;
-  }
-
-  var pathname = route.path;
-  if (pathname.length > 1) {
+  return this.resolve(src, url, req).bind(this).then(function (route) {
+    if (!route) {
+      this.log && this.log.warn({ src: src, url: url }, 'no valid route found for given source');
+      return;
+    }
+  
+    var pathname = route.path;
+    if (pathname.length > 1) {
+      //
+      // remove prefix from src
+      //
+      req._url = url; // save original url
+      req.url = url.substr(pathname.length) || '/';
+    }
+  
     //
-    // remove prefix from src
+    // Perform Round-Robin on the available targets
+    // TODO: if target errors with EHOSTUNREACH we should skip this
+    // target and try with another.
     //
-    req._url = url; // save original url
-    req.url = url.substr(pathname.length) || '/';
-  }
-
-  //
-  // Perform Round-Robin on the available targets
-  // TODO: if target errors with EHOSTUNREACH we should skip this
-  // target and try with another.
-  //
-  var urls = route.urls;
-  var j = route.rr;
-  route.rr = (j + 1) % urls.length; // get and update Round-robin index.
-  var target = route.urls[j];
-
-  //
-  // Fix request url if targetname specified.
-  //
-  if (target.pathname) {
-    req.url = path.join(target.pathname, req.url);
-  }
-
-  //
-  // Host headers are passed through from the source by default
-  // Often we want to use the host header of the target instead
-  //
-  if (target.useTargetHostHeader === true) {
-    req.host = target.host;
-  }
-
-  this.log && this.log.info('Proxying %s to %s', src + url, path.join(target.host, req.url));
-
-  return target;
+    var urls = route.urls;
+    var j = route.rr;
+    route.rr = (j + 1) % urls.length; // get and update Round-robin index.
+    var target = route.urls[j];
+  
+    //
+    // Fix request url if targetname specified.
+    //
+    if (target.pathname) {
+      req.url = path.join(target.pathname, req.url);
+    }
+  
+    //
+    // Host headers are passed through from the source by default
+    // Often we want to use the host header of the target instead
+    //
+    if (target.useTargetHostHeader === true) {
+      req.host = target.host;
+    }
+  
+    this.log && this.log.info('Proxying %s to %s', src + url, path.join(target.host, req.url));
+  
+    return target;
+  });
 };
 
 ReverseProxy.prototype._getSource = function (req) {

--- a/test/test_custom_resolver.js
+++ b/test/test_custom_resolver.js
@@ -159,61 +159,71 @@ describe("Custom Resolver", function(){
 
     proxy.register('mysite.example.com', 'http://127.0.0.1:9999');
     proxy.addResolver(resolver);
-
-    result = proxy.resolve('randomsite.example.com', '/anywhere');
-
     // must match the resolver
-    expect(result).to.not.be.null;
-    expect(result).to.not.be.undefined;
-    expect(result.urls.length).to.be.above(0);
-    expect(result.urls[0].hostname).to.be.eq('172.12.0.1');
+    return proxy.resolve('randomsite.example.com', '/anywhere')
+    .then(function (result) {
+        expect(result).to.not.be.null;
+        expect(result).to.not.be.undefined;
+        expect(result.urls.length).to.be.above(0);
+        expect(result.urls[0].hostname).to.be.eq('172.12.0.1');
 
-    // expect route to match resolver even though it matches registered address
-    result = proxy.resolve('mysite.example.com', '/somewhere');
-    expect(result.urls[0].hostname).to.be.eq('172.12.0.1');
+        // expect route to match resolver even though it matches registered address
+        return proxy.resolve('mysite.example.com', '/somewhere');
+      })
+      .then(function (result) {
+        expect(result.urls[0].hostname).to.be.eq('172.12.0.1');
+        
+        // use default resolver, as custom resolver should ignore input.
+        return proxy.resolve('mysite.example.com', '/ignore');
+      })
+      .then(function (result) {
+        expect(result).to.be.undefined;
 
-    // use default resolver, as custom resolver should ignore input.
-    result = proxy.resolve('mysite.example.com', '/ignore');
-    expect(result.urls[0].hostname).to.be.eq('127.0.0.1');
+        // make custom resolver low priority and test.
+        // result should match default resolver
+        resolver.priority = -1;
+        proxy.addResolver(resolver);
+        return proxy.resolve('mysite.example.com', '/somewhere');
+      })
+      .then(function (result) {
+        expect(result.urls[0].hostname).to.be.eq('127.0.0.1');
 
+        // both custom and default resolvers should ignore
+        return proxy.resolve('somesite.example.com', '/ignore');
+      })
+      .then(function (result) {
+        expect(result).to.be.undefined;
+        proxy.removeResolver(resolver);
 
-    // make custom resolver low priority and test.
-    // result should match default resolver
-    resolver.priority = -1;
-    proxy.addResolver(resolver);
-    result = proxy.resolve('mysite.example.com', '/somewhere');
-    expect(result.urls[0].hostname).to.be.eq('127.0.0.1');
+        // for path-based routing
+        // when resolver path doesn't match that of url, skip
 
+        resolver = function () {
+          return {
+            path: '/notme',
+            url: 'http://172.12.0.1/home'
+          }
+        };
+        resolver.priority = 1;
+        proxy.addResolver(resolver);
 
-    // both custom and default resolvers should ignore
-    result = proxy.resolve('somesite.example.com', '/ignore');
-    expect(result).to.be.undefined;
+        return proxy.resolve('somesite.example.com', '/notme');
+      })
+      .then(function (result) {
+        expect(result).to.not.be.undefined;
+        expect(result.urls[0].hostname).to.be.eq('172.12.0.1');
 
-    proxy.removeResolver(resolver);
-    // for path-based routing
-    // when resolver path doesn't match that of url, skip
+        return proxy.resolve('somesite.example.com', '/notme/somewhere');
+      })
+      .then(function (result) {
+        expect(result.urls[0].hostname).to.be.eq('172.12.0.1');
 
-    resolver = function () {
-      return {
-        path: '/notme',
-        url: 'http://172.12.0.1/home'
-      }
-    };
-    resolver.priority = 1;
-    proxy.addResolver(resolver);
-
-    result = proxy.resolve('somesite.example.com', '/notme');
-    expect(result).to.not.be.undefined;
-    expect(result.urls[0].hostname).to.be.eq('172.12.0.1');
-
-    result = proxy.resolve('somesite.example.com', '/notme/somewhere');
-    expect(result.urls[0].hostname).to.be.eq('172.12.0.1');
-
-    result = proxy.resolve('somesite.example.com', '/itsme/somewhere');
-    expect(result).to.be.undefined;
-
-
-    proxy.close();
+        return proxy.resolve('somesite.example.com', '/itsme/somewhere');
+      })
+      .then(function (result) {
+        expect(result).to.be.undefined;
+        proxy.close();
+      });
   });
 
 });


### PR DESCRIPTION
Relates to #92 
Now you can return promises from custom resolvers.
- also tests are updated to use promises.