### PR TITLE
Prevent challenge-response server from serving sensitive data

### DIFF
--- a/lib/letsencrypt.js
+++ b/lib/letsencrypt.js
@@ -24,6 +24,8 @@ function init(certPath, port, logger){
   var url = require('url');
   var fs = require('fs');
 
+  const CHALLENGE_FILENAME_REGEX = /(?:^|\/)([a-zA-Z0-9_-]{30,})$/;
+
   logger && logger.info('Initializing letsencrypt, path %s, port: %s', certPath, port);
 
   leStoreConfig = {
@@ -41,21 +43,24 @@ function init(certPath, port, logger){
   };
 
   // we need to proxy for example: 'example.com/.well-known/acme-challenge' -> 'localhost:port/example.com/'
-  http.createServer(function (req, res){
-    var uri = url.parse(req.url).pathname;
-    var filename = path.join(certPath, uri);
-    var isForbiddenPath = uri.length < 3 || filename.indexOf(certPath) !== 0;
+  // or enable port-forwarding in the router: WAN port 80 -> local-redbird-ip:port
+  http.createServer(function(req, res) {
+    var reqHostname = String(req.headers.host).split(':', 1)[0];
+    var reqPath = url.parse(req.url).pathname;
+    var challengeFileName = CHALLENGE_FILENAME_REGEX.test(reqPath) && RegExp.$1;
+    var challengeFilePath = challengeFileName && path.join(certPath, reqHostname, '.well-known/acme-challenge', challengeFileName);
+    var isForbiddenPath = !challengeFileName || challengeFilePath.indexOf(certPath) !== 0;
 
     if (isForbiddenPath) {
-      logger && logger.info('Forbidden request on LetsEncrypt port %s: %s', port, filename);
+      logger && logger.info('Forbidden request on LetsEncrypt port %s: %s', port, reqPath);
       res.writeHead(403);
       res.end();
       return;
     }
 
-    logger && logger.info('LetsEncrypt CA trying to validate challenge %s', filename);
+    logger && logger.info('LetsEncrypt CA trying to validate challenge %s', challengeFilePath);
 
-    fs.stat(filename, function(err, stats) {
+    fs.stat(challengeFilePath, function(err, stats) {
       if (err || !stats.isFile()) {
         res.writeHead(404, {"Content-Type": "text/plain"});
         res.write("404 Not Found\n");
@@ -64,7 +69,7 @@ function init(certPath, port, logger){
       }
 
       res.writeHead(200);
-      fs.createReadStream(filename, "binary").pipe(res);
+      fs.createReadStream(challengeFilePath, 'binary').pipe(res);
     });
 
   }).listen(port);


### PR DESCRIPTION
With an letsencrypt-enabled Redbird running *not* inside a Docker container but directly in the LAN (e.g. on a Raspberry Pi), currently every computer inside the LAN is able to obtain the private keys for the domains directly from Redbirds challenge-response server, e.g. by requesting:

http://raspi:3000/my.example.com/privkey.pem

This might be a security concern. I think the challenge-response server should only serve actual challenge-response requests from letsencrypt, i.e. serving files from {certsDir}/{domain}/.well-known/acme-challenge/{challenge-response-file}

My change in letsencrypt.js ensures this by using only the hostname (without port) and the regex-checked challenge-part of the incoming HTTP request. 

The solution works also when the port-3000 server is not accessed proxied via Redbird, but directly by port-forwarding 80->redbird-ip:3000 in a hardware router.