### PR TITLE
Fixed: Letsencrypt port leaks private SSL keys

### DIFF
--- a/lib/letsencrypt.js
+++ b/lib/letsencrypt.js
@@ -41,7 +41,7 @@ function init(certPath, port, logger){
   };
 
   const WELL_KNOWN_URI_FRAGMENT = '/.well-known/acme-challenge/';
-  const WELL_KNOWN_PATH_FRAGMENT = path.resolve(WELL_KNOWN_URI_FRAGMENT);
+  const WELL_KNOWN_PATH_FRAGMENT = path.normalize(WELL_KNOWN_URI_FRAGMENT);
 
   // There are 2 ways to make the challenge files accessible for the LetsEncrypt CA:
   //  (a) by adding a Redbird route, e.g.

--- a/lib/letsencrypt.js
+++ b/lib/letsencrypt.js
@@ -40,22 +40,40 @@ function init(certPath, port, logger){
     debug: false
   };
 
-  // we need to proxy for example: 'example.com/.well-known/acme-challenge' -> 'localhost:port/example.com/'
+  const WELL_KNOWN_URI_FRAGMENT = '/.well-known/acme-challenge/';
+  const WELL_KNOWN_PATH_FRAGMENT = path.resolve(WELL_KNOWN_URI_FRAGMENT);
+
+  // There are 2 ways to make the challenge files accessible for the LetsEncrypt CA:
+  //  (a) by adding a Redbird route, e.g.
+  //      proxy.register('example.com/.well-known', 'http://127.0.0.1/3000/example.com/.well-known');
+  /// (b) by enabling port-forwarding in the (hardware/software) router, e.g.
+  //      WAN port 80 -> {redbird-IP}:3000
   http.createServer(function (req, res){
     var uri = url.parse(req.url).pathname;
-    var filename = path.join(certPath, uri);
-    var isForbiddenPath = uri.length < 3 || filename.indexOf(certPath) !== 0;
+    // split requested path into domain name and challenge-filename; (using split-limit 2 here suffices to to detect fishy urls)
+    var domainAndFilename = uri.split(WELL_KNOWN_URI_FRAGMENT, 2);
+    var isForbidden = (domainAndFilename.length !== 2);
+    var responseFileName = !isForbidden && domainAndFilename[1];
+    // when using port-forwarding instead of Redbird route,
+    // domainAndFilename[0] will be '' while the HTTP `host` header contains the actual domain being validated
+    var domainName = isForbidden ? null : (domainAndFilename[0] || String(req.headers.host).split(':', 1)[0]);
+    var responseFilePath = responseFileName && domainName &&
+                           path.join(certPath, domainName, WELL_KNOWN_PATH_FRAGMENT, responseFileName);
 
-    if (isForbiddenPath) {
-      logger && logger.info('Forbidden request on LetsEncrypt port %s: %s', port, filename);
+    isForbidden = isForbidden || !responseFilePath ||
+                  responseFilePath.indexOf(certPath) !== 0 ||
+                  responseFilePath.indexOf(WELL_KNOWN_PATH_FRAGMENT) < certPath.length;
+
+    if (isForbidden) {
+      logger && logger.info('Forbidden request on LetsEncrypt port %s: %s', port, uri);
       res.writeHead(403);
       res.end();
       return;
     }
 
-    logger && logger.info('LetsEncrypt CA trying to validate challenge %s', filename);
+    logger && logger.info('LetsEncrypt CA trying to validate challenge %s', responseFilePath);
 
-    fs.stat(filename, function(err, stats) {
+    fs.stat(responseFilePath, function(err, stats) {
       if (err || !stats.isFile()) {
         res.writeHead(404, {"Content-Type": "text/plain"});
         res.write("404 Not Found\n");
@@ -64,7 +82,7 @@ function init(certPath, port, logger){
       }
 
       res.writeHead(200);
-      fs.createReadStream(filename, "binary").pipe(res);
+      fs.createReadStream(responseFilePath, "binary").pipe(res);
     });
 
   }).listen(port);


### PR DESCRIPTION
With a letsencrypt-enabled Redbird running _not_ inside a Docker container but directly in the LAN (e.g. on a Raspberry Pi), currently every computer inside the LAN is able to obtain the private keys for the domains directly from Redbirds challenge-response server, e.g. by requesting:

http://raspi:3000/my.example.com/privkey.pem

This might be a security concern. I think the challenge-response server should only serve actual challenge-response requests from letsencrypt, i.e. serving files from {certsDir}/{domain}/.well-known/acme-challenge/{challenge-response-file}

My changes in letsencrypt.js ensure that only challenge files from approriate directories are delivered.

Also, the challenge-response server can now be exposed to the outside world in two ways, per Redbird proxy route and/or directly by port-forwarding 80->redbird-ip:3000 in a hardware/software router. (I added an "extensive" comment above the createServer-call in letsencrypt.js. Maybe the examples there should be placed more prominent, maybe in README.md?)