### PR TITLE
Letsencrypt ACME response server leaks private SSL keys

### DIFF
--- a/lib/letsencrypt.js
+++ b/lib/letsencrypt.js
@@ -44,7 +44,7 @@ function init(certPath, port, logger){
   http.createServer(function (req, res){
     var uri = url.parse(req.url).pathname;
     var filename = path.join(certPath, uri);
-    var isForbiddenPath = uri.length < 3 || filename.indexOf(certPath) !== 0;
+    var isForbiddenPath = uri.indexOf('/.well-known/acme-challenge/') < 0 || filename.indexOf(certPath) !== 0;
 
     if (isForbiddenPath) {
       logger && logger.info('Forbidden request on LetsEncrypt port %s: %s', port, filename);


### PR DESCRIPTION
If LAN clients have direct (un-proxied) access to Redbird's LE challenge-response server, they can obtain all of Redbird's private SSL keys, e.g.

http://local-server-ip:3000/my.example.com/privkey.pem

The ACME response server should reject URIs without the "/.well-known/acme-challenge/" part.
I added this check.