### PR TITLE
Support Custom http-proxy module Options

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -273,10 +273,7 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
 
     _this._getTarget(src, req).then(function (target) {
       if (target) {
-        let options = {
-          target: target,
-          ..._this.opts.httpProxy,
-        };
+        let options = Object.assign({}, { target: target}, _this.opts.httpProxy);
         proxy.web(req, res, options);
       } else {
         respondNotFound(req, res);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -270,11 +270,12 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
   var httpsServer = this.httpsServer = https.createServer(ssl, function (req, res) {
 
     var src = _this._getSource(req);
+    var httpProxyOpts = Object.assign({}, _this.opts.httpProxy);
 
     _this._getTarget(src, req).then(function (target) {
       if (target) {
-        let options = Object.assign({}, { target: target}, _this.opts.httpProxy);
-        proxy.web(req, res, options);
+        httpProxyOpts.target = target;
+        proxy.web(req, res, httpProxyOpts);
       } else {
         respondNotFound(req, res);
       }

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -26,7 +26,11 @@ function ReverseProxy(opts) {
   }
 
   this.opts = opts = opts || {};
-
+  
+  if (this.opts.httpProxy == undefined) {
+        this.opts.httpProxy = {};
+  }
+  
   var log;
   if (opts.bunyan !== false) {
     log = this.log = bunyan.createLogger(opts.bunyan || {
@@ -269,7 +273,11 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
 
     _this._getTarget(src, req).then(function (target) {
       if (target) {
-        proxy.web(req, res, { target: target });
+        let options = {
+          target: target,
+          ..._this.opts.httpProxy,
+        };
+        proxy.web(req, res, options);
       } else {
         respondNotFound(req, res);
       }


### PR DESCRIPTION
This change will allow to include an object under the httpProxy key with custom options for the http-proxy module.
In the following example the changeOrigin setting of http-proxy is being set to True.
```
var proxy = require("redbird")({
    xfwd: false,
    httpProxy: {
        changeOrigin: true,
    },
    letsencrypt: {
        path: __dirname + "/certs",
        port: 9999,
    },
    port: 80,
    ssl: {
        http2: true,
        port: 443,
    },
});
```