### PR TITLE
fix broken custom resolver logic introduced with async resolvers

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -533,13 +533,16 @@ ReverseProxy.prototype.resolve = function (host, url, req) {
     promiseArray.push(this.resolvers[i].call(this,host, url, req));
   }
 
-  return Promise.all(promiseArray).then(function (data) {
-    var route = data[0];
-    if (route && (route = ReverseProxy.buildRoute(route))) {
-      // ensure resolved route has path that prefixes URL
-      // no need to check for native routes.
-      if (!route.isResolved || route.path === '/' || startsWith(url, route.path)) {
-        return route;
+  return Promise.all(promiseArray).then(function (resolverResults) {
+    while (resolverResults.length) {
+      var route = resolverResults.shift();
+
+      if (route && (route = ReverseProxy.buildRoute(route))) {
+        // ensure resolved route has path that prefixes URL
+        // no need to check for native routes.
+        if (!route.isResolved || route.path === '/' || startsWith(url, route.path)) {
+          return route;
+        }
       }
     }
   })

--- a/test/test_custom_resolver.js
+++ b/test/test_custom_resolver.js
@@ -178,7 +178,7 @@ describe("Custom Resolver", function(){
         return proxy.resolve('mysite.example.com', '/ignore');
       })
       .then(function (result) {
-        expect(result).to.be.undefined;
+        expect(result.urls[0].hostname).to.be.eq('127.0.0.1');
 
         // make custom resolver low priority and test.
         // result should match default resolver


### PR DESCRIPTION
Was playing around in this module and noticed a few oddities in the custom resolvers logic.

First thing I noticed is that the results from the custom resolvers were used differently between the async and sync versions. In the sync version, the resolvers are processed serially until the match criteria is met (`!route.isResolved || route.path === '/' || startsWith(url, route.path)`). In the async version, the first result is used—period.

Having fixed that, I noticed a test introduced in the first implementation of the async handler appears, to my eyes, to be wrong. In that test, you have a [higher priority](https://github.com/jasisk/redbird/blob/5b48e38b2a92bcdc26d71abc2c470882af0c2c7d/test/test_custom_resolver.js#L159) custom resolver that [only mutates if the path does not match `/ignore`](https://github.com/OptimalBits/redbird/blob/ccbf1e06a9308f529887204adb9cc8ae30da5cf8/test/test_custom_resolver.js#L156). the `mysite.example.com` route gets mapped to `127.0.0.1` [via the default resolver](https://github.com/OptimalBits/redbird/blob/ccbf1e06a9308f529887204adb9cc8ae30da5cf8/test/test_custom_resolver.js#L161). However, [in the test case](https://github.com/OptimalBits/redbird/blob/ccbf1e06a9308f529887204adb9cc8ae30da5cf8/test/test_custom_resolver.js#L177-L181), a request made to `mysite.example.com/ignore` (which should, from my understand, be ignored by the custom resolver but mapped to `127.0.0.1` by the default resolver) is written to expect not to be resolved. I've adjusted the test case for this behavior (jasisk@43711f4) so please let me know if my understanding is off.

I've tried to maintain the current structure / language feature usage to what is already in the code base to avoid relying on newer runtimes than was previously required. Happy to adjust if necessary.