### PR TITLE
Fix documentation on disabling ssl redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,6 @@ __Arguments__
     		key: keyPath,
     		cert: certPath,
     		ca: caPath // Optional.
-            redirect: true, // Disable HTTPS autoredirect to this route.
             http2: false, //Optional, setting to true enables http2/spdy support
             serverModule : require('https') // Optional, override the https server module used to listen for https or http2 connections.  Default is require('https') or require('spdy')
     	}
@@ -505,6 +504,7 @@ __Arguments__
     {ssl : true} // Will use default ssl certificates.
     {ssl: {
         redirectPort: port, // optional https port number to be redirected if entering using http.
+        redirect: true, // False to disable HTTPS autoredirect to this route.
     	key: keyPath,
     	cert: certPath,
     	ca: caPath // optional


### PR DESCRIPTION
It used to say that it was an option to redbird constructor, when it is actually only an option to the register() call