### PR TITLE
Updated example when using LetsEncrypt and https2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,14 @@ redbird.register('example.com', 'http://172.60.80.2:8082', {
 // HTTP2 Support using LetsEncrypt for the certificates
 //
 var proxy = require('redbird')({
+  port: 80, // http port is needed for LetsEncrypt challenge during request / renewal. Also enables automatic http->https redirection for registered https routes. 
   letsencrypt: {
     path: __dirname + '/certs',
-    port:9999
+    port: 9999 // LetsEncrypt minimal web server port for handling challenges. Routed 80->9999, no need to open 9999 in firewall. Default 3000 if not defined.
   },
   ssl: {
     http2: true,
+    port: 443, // SSL port used to serve registered https routes with LetsEncrypt certificate.
   }
 });
 


### PR DESCRIPTION
Added required ports 80 and 443 in the configuration example. Added describing comment for these.