### PR TITLE
Fix indentation in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ proxy.register("balance.me", "http://172.17.43.6:8080");
 // LetsEncrypt support
 // With Redbird you can get zero conf and automatic SSL certificates for your domains
 redbird.register('example.com', 'http://172.60.80.2:8082', {
-	ssl: {
+  ssl: {
     letsencrypt: {
       email: 'john@example.com', // Domain owner/admin email
       production: true, // WARNING: Only use this flag when the proxy is verified to work correctly to avoid being banned!


### PR DESCRIPTION
Thanks for the project! This fixes the indentation in the example in the readme.