### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
 
 node_js:
-  - '4.5'
+  - 'node'
+  - '10'
+  - '8'
+  - '6'


### PR DESCRIPTION
Node.js 4 has already reached its EOL and we should test the current stable and LTS branches.

See https://github.com/nodejs/Release/blob/master/README.md