### PR TITLE
Fix `secure: false` option not being respected.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -186,7 +186,7 @@ ReverseProxy.prototype.setupHttpProxy = function (proxy, websocketsUpgrade, log,
         if (shouldRedirectToHttps(_this.certs, src, target, _this)) {
           redirectToHttps(req, res, target, opts.ssl, log);
         } else {
-          proxy.web(req, res, { target: target, secure: (proxy.options && proxy.options.secure) || true});
+          proxy.web(req, res, { target: target, secure: !proxy.options || (proxy.options.secure !== false)});
         }
       } else {
         respondNotFound(req, res);


### PR DESCRIPTION
With the old logic, setting `secure: false` would always get converted to `true`, since the old code would evaluate to `false || true` which is always `true`.