### PR TITLE
Adding option to disable older SSL/TLS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,10 +508,14 @@ __Arguments__
         redirect: true, // False to disable HTTPS autoredirect to this route.
     	key: keyPath,
     	cert: certPath,
-    	ca: caPath // optional
+    	ca: caPath, // optional
+    	secureOptions: constants.SSL_OP_NO_TLSv1 //optional, see below 
     	}
     }
 ```
+> _Note: if you need to use **ssl.secureOptions**, to disable older, insecure TLS versions, import crypto/constants first:_
+
+> `const { constants } = require('crypto')`
 
 ---------------------------------------
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -252,6 +252,11 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
     key: getCertData(sslOpts.key),
     cert: getCertData(sslOpts.cert)
   };
+  
+  // Allows the option to disable older SSL/TLS versions
+  if(sslOpts.secureOptions) {
+    ssl.secureOptions = sslOpts.secureOptions;
+  }
 
   if (sslOpts.ca) {
     ssl.ca = getCertData(sslOpts.ca, true);


### PR DESCRIPTION
In response to [Issue 206](https://github.com/OptimalBits/redbird/issues/206) - this change allows one to **optionally** pass in "secureOptions" when starting an https proxy, as you normally would to an https config object - redbird will pass it along into the https proxy server and you can effectively disable TLS 1.0 (or other older, vulnerable versions of SSL/TLS).

See the following for an example of disabling TLS 1.0 in a node https server: https://stackoverflow.com/questions/31201029/how-to-disable-tls-1-0-and-use-only-tls-1-1-using-nodejs

Note that I have tested this both with and without this new option. It works as expected and has no effect on existing redbird deployments.