### PR TITLE
Add SNI-Callback to dynamically create missing certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ redbird.register('example.com', 'http://172.60.80.2:8082', {
 // HTTP2 Support using LetsEncrypt for the certificates
 //
 var proxy = require('redbird')({
-  port: 80, // http port is needed for LetsEncrypt challenge during request / renewal. Also enables automatic http->https redirection for registered https routes. 
+  port: 80, // http port is needed for LetsEncrypt challenge during request / renewal. Also enables automatic http->https redirection for registered https routes.
   letsencrypt: {
     path: __dirname + '/certs',
     port: 9999 // LetsEncrypt minimal web server port for handling challenges. Routed 80->9999, no need to open 9999 in firewall. Default 3000 if not defined.
@@ -235,7 +235,7 @@ var redbird = new require('redbird')({
 			ip: '123.45.67.11', // assigned to my-other-domain.com
 			key: 'certs/my-other-domain.key',
 			cert: 'certs/my-other-domain.crt',
-		}				
+		}
 	]
 });
 
@@ -375,7 +375,7 @@ Resolvers can be defined when initializing the proxy object with the `resolvers`
 
 ```
 
-### Adding and Removing Resolvers at Runtime.
+### Adding and Removing Resolvers at Runtime
 
 You can add or remove resolvers at runtime, this is useful in situations where your upstream is tied to a service discovery service system.
 
@@ -400,35 +400,75 @@ setTimeout(function() {
 }, 600000);
 ```
 
+### Dynamic letsencrypt setup with undetermined domain names
+
+```javascript
+const proxy = require('redbird')({
+  port: 8080,
+  resolvers: [
+    myCustomResolver // custom resolver logic matching my.backend
+  ],
+  letsencrypt: {
+    path: "/path/to/certs",
+    port: 9999 // LetsEncrypt minimal web server port for handling challenges. Routed 80->9999, no need to open 9999 in firewall. Default 3000 if not defined.
+  },
+  ssl: {
+    http2: false, // not working with node > 10
+    port: 8443, // SSL port used to serve registered https routes with LetsEncrypt certificate.
+  },
+  SNICallback: registerHost
+});
+
+var registeredHosts = [];
+function registerHost(hostname) {
+  if (registeredHosts[hostname]) {
+    return hostname;
+  }
+  // Attention: You should verify that the domain belongs to you at this point to prevent bogus requests spaming letsencrypt.
+  console.log('Registering host ' + hostname);
+  proxy.register(hostname, 'http://my.backend/', {
+    useTargetHostHeader: true,
+    ssl: {
+      letsencrypt: {
+        email: 'info@john.doe',
+        production: true, // Use with care!
+      }
+    }
+  });
+  registeredHosts[hostname] = true;
+  return null; // Aborts request as `proxy.register` is asynchronous. Is not noticable in browser, though.
+}
+```
+
 ## Replacing the default HTTP/HTTPS server modules
 
-By passing `serverModule: module` or `ssl: {serverModule : module}` you can override the default http/https 
+By passing `serverModule: module` or `ssl: {serverModule : module}` you can override the default http/https
 servers used to listen for connections with another module.
 
-One application for this is to enable support for PROXY protocol: This is useful if you want to use a module like 
-[findhit-proxywrap](https://github.com/findhit/proxywrap) to enable support for the 
+One application for this is to enable support for PROXY protocol: This is useful if you want to use a module like
+[findhit-proxywrap](https://github.com/findhit/proxywrap) to enable support for the
 [PROXY protocol](http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt).
- 
-                                                                  
-PROXY protocol is used in tools like HA-Proxy, and can be optionally enabled in Amazon ELB load balancers to pass the 
-original client IP when proxying TCP connections (similar to an X-Forwarded-For header, but for raw TCP). This is useful 
-if you want to run redbird on AWS behind an ELB load balancer, but have redbird terminate any HTTPS connections so you 
-can have SNI/Let's Encrypt/HTTP2support. With this in place Redbird will see the client's IP address rather 
+
+
+PROXY protocol is used in tools like HA-Proxy, and can be optionally enabled in Amazon ELB load balancers to pass the
+original client IP when proxying TCP connections (similar to an X-Forwarded-For header, but for raw TCP). This is useful
+if you want to run redbird on AWS behind an ELB load balancer, but have redbird terminate any HTTPS connections so you
+can have SNI/Let's Encrypt/HTTP2support. With this in place Redbird will see the client's IP address rather
 than the load-balancer's, and pass this through in an X-Forwarded-For header.
 
 ````javascript
 //Options for proxywrap. This means the proxy will also respond to regular HTTP requests without PROXY information as well.
-proxy_opts = {strict: false}; 
+proxy_opts = {strict: false};
 proxyWrap = require('findhit-proxywrap');
 var opts = {
     port: process.env.HTTP_PORT,
     serverModule: proxyWrap.proxy( require('http'), proxy_opts),
     ssl: {
         //Do this if you want http2:
-        http2: true,        
+        http2: true,
         serverModule: proxyWrap.proxy(require('spdy').server, proxy_opts),
         //Do this if you only want regular https
-        // serverModule: proxyWrap.proxy( require('http'), proxy_opts), 
+        // serverModule: proxyWrap.proxy( require('http'), proxy_opts),
         port: process.env.HTTPS_PORT,
     }
 }
@@ -481,7 +521,8 @@ __Arguments__
         If you want to disable bunyan, just set this option to false. Keep in mind that
         having logs enabled incours in a performance penalty of about one order of magnitude per request.
         resolvers: {Function | Array}  a list of custom resolvers. Can be a single function or an array of functions. See more details about resolvers above.
-        serverModule : {Module} Optional - Override the http server module used to listen for http connections.  Default is require('http') 
+        serverModule : {Module} Optional - Override the http server module used to listen for http connections.  Default is require('http')
+        SNICallback: Function(hostname): string Is called before a SNI lookup is done. Can be used to setup unknown letsencrypt hosts. Needs to return the / a new hostname or null to abort the SNI lookup.
 	}
 ```
 
@@ -509,7 +550,7 @@ __Arguments__
     	key: keyPath,
     	cert: certPath,
     	ca: caPath, // optional
-    	secureOptions: constants.SSL_OP_NO_TLSv1 //optional, see below 
+    	secureOptions: constants.SSL_OP_NO_TLSv1 //optional, see below
     	}
     }
 ```

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -26,11 +26,11 @@ function ReverseProxy(opts) {
   }
 
   this.opts = opts = opts || {};
-  
+
   if (this.opts.httpProxy == undefined) {
         this.opts.httpProxy = {};
   }
-  
+
   var log;
   if (opts.bunyan !== false) {
     log = this.log = pino(opts.bunyan || {
@@ -240,6 +240,12 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
 
   var ssl = {
     SNICallback: function (hostname, cb) {
+      if (null == certs[hostname] && _this.opts.SNICallback && _.isFunction(_this.opts.SNICallback)) {
+        hostname = _this.opts.SNICallback(hostname);
+        if (null == hostname) {
+          return; // Allows request abortion if needed
+        }
+      }
       if (cb) {
         cb(null, certs[hostname]);
       } else {
@@ -252,7 +258,7 @@ ReverseProxy.prototype.setupHttpsProxy = function (proxy, websocketsUpgrade, log
     key: getCertData(sslOpts.key),
     cert: getCertData(sslOpts.cert)
   };
-  
+
   // Allows the option to disable older SSL/TLS versions
   if(sslOpts.secureOptions) {
     ssl.secureOptions = sslOpts.secureOptions;


### PR DESCRIPTION
I have a use case where I needed redbird to dynamically issue certificates for undetermined domains. For this I added a new callback to call `proxy.register` for yet unregistered hostnames.

It is not the most elegant solution, mostly caused by `proxy.register` being asynchronous and the need to abort the initial request. I wanted to keep it simple, though and did not touch more code than needed.