### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ proxy.register("balance.me", "http://172.17.43.6:8080");
 
 // LetsEncrypt support
 // With Redbird you can get zero conf and automatic SSL certificates for your domains
-redbird.register('example.com', 'http://172.60.80.2:8082', {
+proxy.register('example.com', 'http://172.60.80.2:8082', {
   ssl: {
     letsencrypt: {
       email: 'john@example.com', // Domain owner/admin email


### PR DESCRIPTION
I guess this is probably a typo as the `redbird` variable doesn't exist.