### PR TITLE
Add support for custom headers

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -26,6 +26,9 @@ function ReverseProxy(opts) {
 
   this.opts = opts = opts || {};
 
+  opts.customHeaders = opts.customHeaders || {};
+  this.opts = opts;
+
   if (this.opts.httpProxy == undefined) {
     this.opts.httpProxy = {};
   }
@@ -103,12 +106,19 @@ function ReverseProxy(opts) {
     });
 
     //
-    // Support NTLM auth
+    // Support NTLM auth and custom headers
     //
-    if (opts.ntlm) {
+    if (opts.ntlm || Object.keys(opts.customHeaders).length) {
       proxy.on('proxyRes', function (proxyRes) {
-        var key = 'www-authenticate';
-        proxyRes.headers[key] = proxyRes.headers[key] && proxyRes.headers[key].split(',');
+        if (opts.ntlm) {
+          var key = 'www-authenticate';
+          proxyRes.headers[key] = proxyRes.headers[key] && proxyRes.headers[key].split(',');
+        }
+        if (Object.keys(opts.customHeaders).length) {
+          Object.keys(opts.customHeaders).forEach(function (headerKey) {
+            proxyRes.headers[headerKey] = opts.customHeaders[headerKey];
+          })
+        }
       });
     }
 


### PR DESCRIPTION
With this PR, you can add custom headers to your proxy.

```
var proxy = require("redbird")({
  port: process.env.PORT,
  customHeaders: {
    "x-frame-options": "deny",
  },
});
```