### PR TITLE
Replaced depcrated le-store-certbot with le-store-fs

### DIFF
--- a/lib/letsencrypt.js
+++ b/lib/letsencrypt.js
@@ -83,7 +83,7 @@ function getCertificates(domain, email, production, renew, logger) {
   var le;
 
   // Storage Backend
-  var leStore = require('le-store-certbot').create(leStoreConfig);
+  var leStore = require('le-store-fs').create(leStoreConfig);
 
   // ACME Challenge Handlers
   var leChallenge = require('le-challenge-fs').create({


### PR DESCRIPTION
le-store-certbot is depracated and is replaced by le-store-fs, here's the issue which is caused by the deprecated package https://github.com/OptimalBits/redbird/issues/269